### PR TITLE
[codex] Support relative event date filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# AGENTS.md
+
+## Overview
+
+This file gives coding agents a quick operating guide for this repository.
+
+- Repository: `junto`
+- Primary app: `app/`
+- Stack: TypeScript, Node.js, Express, Mongoose, Jest
+
+## Goals
+
+Describe the primary product and engineering goals here.
+
+- Goal 1: `TODO`
+- Goal 2: `TODO`
+- Goal 3: `TODO`
+
+## Repository Layout
+
+```text
+.
+├── app/
+│   ├── src/
+│   ├── tests/
+│   ├── package.json
+│   ├── tsconfig.json
+│   └── tsconfig.build.json
+├── docs/
+├── docker-compose.yml
+└── README.md
+```
+
+## Working Agreements
+
+- Prefer small, focused changes.
+- Do not revert unrelated local changes.
+- Keep changes aligned with existing code style and patterns.
+- Add or update tests when behavior changes.
+- Prefer fixing root causes over patching symptoms.
+
+## Setup
+
+Run commands from `app/` unless noted otherwise.
+
+```bash
+npm install
+```
+
+## Common Commands
+
+```bash
+# Development
+cd app && npm run dev
+
+# Build
+cd app && npm run build
+
+# Tests
+cd app && npm test
+
+# Focused test run
+cd app && npm test -- --config jest.config.ts --runInBand tests/requests/events.test.ts
+
+# Lint
+cd app && npm run lint
+```
+
+## Build Notes
+
+- Production build output goes to `app/dist/`.
+- The build uses `tsconfig.build.json`.
+- Source and test-adjacent generated `.js` files should not be recreated in `app/src/` or `app/tests/`.
+
+## Testing Expectations
+
+- Add unit tests for helpers, middleware, and services when logic changes.
+- Add request-level tests for endpoint behavior changes.
+- Prefer targeted test runs while iterating.
+- Run the most relevant tests before finishing work.
+
+## Code Areas
+
+### API and Routes
+
+- Location: `app/src/routes/`
+- Request handlers: `app/src/requests/`
+- Services: `app/src/services/`
+
+### Data Layer
+
+- Models: `app/src/models/`
+- Schemas and validation: `app/src/schemas/`
+
+### Tests
+
+- Request tests: `app/tests/requests/`
+- Middleware tests: `app/tests/middlewares/`
+- Helper tests: `app/tests/helpers/`
+- Model tests: `app/tests/models/`
+- Service tests: `app/tests/services/`
+
+## Change Checklist
+
+Before finishing a task, check:
+
+- Behavior change is implemented.
+- Relevant tests were added or updated.
+- Build still succeeds.
+- Relevant test suite passes.
+- No accidental generated files were introduced outside `dist/`.
+
+## PR Guidance
+
+When opening a PR, include:
+
+- What changed
+- Why it changed
+- User or developer impact
+- Validation performed
+
+## Known Caveats
+
+- Jest should be run with `jest.config.ts`.
+- Stale generated files can cause duplicate Jest config or mock issues if they appear outside `dist/`.
+- There are duplicate `GET /` route registrations in `app/src/routes/event.ts`; review route order carefully when changing event listing behavior.
+
+## Project-Specific Conventions
+
+Fill in any conventions that agents should follow here.
+
+- Naming: `TODO`
+- Branching: `TODO`
+- Review expectations: `TODO`
+- Release process: `TODO`
+
+## Contacts
+
+Add project owners or team references here.
+
+- Engineering owner: `TODO`
+- Product owner: `TODO`
+- Slack / docs / issue tracker: `TODO`

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -6,3 +6,8 @@ uploads/
 docs
 coverage
 coverage.txt
+dist/
+*.tsbuildinfo
+src/**/*.js
+tests/**/*.js
+jest.config.js

--- a/app/jest.config.ts
+++ b/app/jest.config.ts
@@ -12,6 +12,7 @@ module.exports = {
         "^@/(.*)$": "<rootDir>/src/$1",
         "^@tests/(.*)$": "<rootDir>/tests/$1"
     },
+    modulePathIgnorePatterns: ["<rootDir>/dist/"],
     coverageReporters: [
         "json-summary",
         "text",

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "dev": "npx tsx watch src/index.ts",
     "lint": "eslint src --ext .ts",
     "fix": "eslint --fix src --ext .ts",

--- a/app/src/helpers/dateFilterHelper.ts
+++ b/app/src/helpers/dateFilterHelper.ts
@@ -1,0 +1,83 @@
+import { type FilterPrefix, type FilterRangeValue, type FilterValue } from "@/types/Filter";
+
+function buildRange(start: Date, endExclusive: Date): FilterRangeValue {
+    return {
+        start,
+        end: new Date(endExclusive.getTime() - 1)
+    };
+}
+
+function startOfDay(value: Date): Date {
+    return new Date(value.getFullYear(), value.getMonth(), value.getDate());
+}
+
+function startOfWeek(value: Date): Date {
+    const result = startOfDay(value);
+    const distanceFromMonday = (result.getDay() + 6) % 7;
+    result.setDate(result.getDate() - distanceFromMonday);
+    return result;
+}
+
+function startOfMonth(value: Date): Date {
+    return new Date(value.getFullYear(), value.getMonth(), 1);
+}
+
+function normalizeRelativeDateValue(value: string): string {
+    return value.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
+}
+
+export function getRelativeDateRange(value: string, referenceDate: Date = new Date()): FilterRangeValue | undefined {
+    const normalizedValue = normalizeRelativeDateValue(value);
+
+    if (normalizedValue === "today") {
+        const start = startOfDay(referenceDate);
+        const endExclusive = new Date(start);
+        endExclusive.setDate(endExclusive.getDate() + 1);
+        return buildRange(start, endExclusive);
+    }
+
+    if (normalizedValue === "this week") {
+        const start = startOfWeek(referenceDate);
+        const endExclusive = new Date(start);
+        endExclusive.setDate(endExclusive.getDate() + 7);
+        return buildRange(start, endExclusive);
+    }
+
+    if (normalizedValue === "this month") {
+        const start = startOfMonth(referenceDate);
+        const endExclusive = new Date(start.getFullYear(), start.getMonth() + 1, 1);
+        return buildRange(start, endExclusive);
+    }
+
+    if (normalizedValue === "this weekend") {
+        const start = startOfWeek(referenceDate);
+        start.setDate(start.getDate() + 5);
+        const endExclusive = new Date(start);
+        endExclusive.setDate(endExclusive.getDate() + 2);
+        return buildRange(start, endExclusive);
+    }
+
+    return undefined;
+}
+
+export function resolveEventDateFilterValue(
+    value: FilterValue,
+    _prefix: FilterPrefix,
+    referenceDate: Date = new Date()
+): FilterValue {
+    if (typeof value !== "string") {
+        return value;
+    }
+
+    const relativeRange = getRelativeDateRange(value, referenceDate);
+    if (relativeRange) {
+        return relativeRange;
+    }
+
+    const parsedDate = new Date(value);
+    if (Number.isNaN(parsedDate.getTime())) {
+        throw new Error("Invalid filter value " + value);
+    }
+
+    return parsedDate;
+}

--- a/app/src/helpers/queryBuilder.ts
+++ b/app/src/helpers/queryBuilder.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { type FilterPrefix, type Filter, isFilterRangeValue } from '@/types/Filter'
+import { type FilterPrefix, type Filter, isFilterRangeValue, type FilterValue } from '@/types/Filter'
 import { type FilterQuery } from "mongoose"
 import { type CoordinatesInput } from '@/types/services/eventService'
 import { SortInput } from '@/types/Sort'
@@ -46,10 +46,10 @@ export function buildGeosearchQuery(value: CoordinatesInput): FilterQuery<Event>
  * @returns {FilterQuery<T>}
  */
 export function buildFilterQuery<T>(dbFilter: Filter[] | undefined): FilterQuery<T> {
-    const query: Record<string, Record<string, unknown>> = {}
+    const query: Record<string, Record<string, FilterValue>> = {}
     if (!dbFilter) return query;
     dbFilter.forEach(filter => {
-        let definition: Record<string, unknown>;
+        let definition: Record<string, FilterValue>;
         if (isFilterRangeValue(filter.value)) {
             if (filter.prefix === 'eq') {
                 definition = { $gte: filter.value.start, $lte: filter.value.end };

--- a/app/src/helpers/queryBuilder.ts
+++ b/app/src/helpers/queryBuilder.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { type FilterPrefix, type Filter, type FilterValue } from '@/types/Filter'
+import { type FilterPrefix, type Filter, isFilterRangeValue } from '@/types/Filter'
 import { type FilterQuery } from "mongoose"
 import { type CoordinatesInput } from '@/types/services/eventService'
 import { SortInput } from '@/types/Sort'
@@ -46,16 +46,31 @@ export function buildGeosearchQuery(value: CoordinatesInput): FilterQuery<Event>
  * @returns {FilterQuery<T>}
  */
 export function buildFilterQuery<T>(dbFilter: Filter[] | undefined): FilterQuery<T> {
-    const query: Record<string, Record<string, FilterValue>> = {}
+    const query: Record<string, Record<string, unknown>> = {}
     if (!dbFilter) return query;
     dbFilter.forEach(filter => {
-        const operator = MongoFilterMap[filter.prefix]
-        let definition = { [operator]: filter.value };
+        let definition: Record<string, unknown>;
+        if (isFilterRangeValue(filter.value)) {
+            if (filter.prefix === 'eq') {
+                definition = { $gte: filter.value.start, $lte: filter.value.end };
+            } else if (filter.prefix === 'after' || filter.prefix === 'min') {
+                definition = { $gte: filter.value.start };
+            } else if (filter.prefix === 'before' || filter.prefix === 'max') {
+                definition = { $lte: filter.value.end };
+            } else {
+                const operator = MongoFilterMap[filter.prefix]
+                definition = { [operator]: filter.value };
+            }
+        } else {
+            const operator = MongoFilterMap[filter.prefix]
+            definition = { [operator]: filter.value };
+        }
+
         if (filter.options) {
             definition = { ...definition, $options: filter.options }
         }
 
-        query[filter.field] = definition
+        query[filter.field] = { ...query[filter.field], ...definition }
     })
     return query;
 }

--- a/app/src/middlewares/filterMiddleware.ts
+++ b/app/src/middlewares/filterMiddleware.ts
@@ -2,20 +2,20 @@ import { NextFunction, Request, Response } from "express";
 import { type Filterable, type FilterPrefix, ARRAY_PREFIXES, SKIP_WORDS, type Filter, type FilterValue, isFilterPrefix, isFilterValue, FilterableField } from "@/types/Filter";
 import { BadInputError } from "@/types/errors/InputError";
 
-function parseFilterValue(filterValue: string, filterPrefix: FilterPrefix, preprocess: (value: FilterValue) => FilterValue = (value) => value): FilterValue {
-    const isArray = filterValue[0] == '[' && filterValue[filterValue.length - 1] == ']';
+function parseFilterValue(filterValue: string, filterPrefix: FilterPrefix, preprocess: (value: FilterValue, prefix: FilterPrefix) => FilterValue = (value) => value): FilterValue {
+    const isArray = filterValue.startsWith('[') && filterValue.endsWith(']');
     const isArrayPrefix = ARRAY_PREFIXES.includes(filterPrefix);
 
     if (isArray !== isArrayPrefix) {
-        throw Error("Invalid filter value " + filterValue)
+        throw new Error("Invalid filter value " + filterValue)
     }
 
     const result = isArray ? filterValue.replace(" ", "").substring(1, filterValue.length - 1).split(',') : filterValue;
 
     if (!isFilterValue(result)) {
-        throw Error("Invalid filter value " + filterValue)
+        throw new Error("Invalid filter value " + filterValue)
     }
-    return preprocess(result);
+    return preprocess(result, filterPrefix);
 }
 
 function parseFilterKey(filterKey: string, filterableFields: FilterableField[]): { filterableField: FilterableField, fieldKey: string, operator: string } | undefined {

--- a/app/src/models/event/statics.ts
+++ b/app/src/models/event/statics.ts
@@ -1,9 +1,10 @@
-import { FilterableField, FilterValue } from "@/types/Filter"
+import { resolveEventDateFilterValue } from "@/helpers/dateFilterHelper";
+import { FilterableField, FilterValue, FilterPrefix } from "@/types/Filter"
 export function getFilterableFields(): FilterableField[] {
     return [
         {
             field: 'date',
-            preprocess: (value: FilterValue) => new Date(value as string)
+            preprocess: (value: FilterValue, prefix: FilterPrefix) => resolveEventDateFilterValue(value, prefix)
         },
         {
             field: 'categories'

--- a/app/src/types/Filter.ts
+++ b/app/src/types/Filter.ts
@@ -1,4 +1,16 @@
-export type FilterPreprocessFunction = (value: FilterValue) => FilterValue
+export const SKIP_WORDS = ['page', 'limit', 'sortByAsc', 'sortByDesc']
+export const ARRAY_PREFIXES = ['in', 'nin']
+export const FILTER_PREFIXES = [...ARRAY_PREFIXES, 'eq', 'max', 'min', 'contains', 'before', 'after'] as const;
+export type FilterPrefix = typeof FILTER_PREFIXES[number];
+export type FilterMap = Record<FilterPrefix, string>
+
+export interface FilterRangeValue {
+    start: Date,
+    end: Date
+}
+
+export type FilterValue = string | number | string[] | number[] | Date | FilterRangeValue
+export type FilterPreprocessFunction = (value: FilterValue, prefix: FilterPrefix) => FilterValue
 export interface FilterableField {
     field: string,
     options?: string,
@@ -7,27 +19,32 @@ export interface FilterableField {
 export interface Filterable {
     getFilterableFields(): FilterableField[]
 }
-
-export type FilterValue = string | number | string[] | number[] | Date
 export interface Filter {
     prefix: FilterPrefix,
     field: string,
     value: FilterValue,
     options?: string
 }
-export const SKIP_WORDS = ['page', 'limit', 'sortByAsc', 'sortByDesc']
-export const ARRAY_PREFIXES = ['in', 'nin']
-export const FILTER_PREFIXES = [...ARRAY_PREFIXES, 'eq', 'max', 'min', 'contains', 'before', 'after'] as const;
-export type FilterPrefix = typeof FILTER_PREFIXES[number];
-export type FilterMap = Record<FilterPrefix, string>
 
 export function isFilterPrefix(value: string): value is FilterPrefix {
     return (FILTER_PREFIXES as readonly string[]).includes(value)
 }
 
-export function isFilterValue(value: string | string[] | number | number[] | Date): value is FilterValue {
+export function isFilterRangeValue(value: unknown): value is FilterRangeValue {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'start' in value &&
+        'end' in value &&
+        value.start instanceof Date &&
+        value.end instanceof Date
+    );
+}
+
+export function isFilterValue(value: string | string[] | number | number[] | Date | FilterRangeValue): value is FilterValue {
     return (
         value instanceof Date ||
+        isFilterRangeValue(value) ||
         typeof value === 'string' ||
         typeof value === 'number' ||
         (Array.isArray(value) && value.every(v => typeof v === 'string')) ||

--- a/app/tests/helpers/dateFilterHelper.test.ts
+++ b/app/tests/helpers/dateFilterHelper.test.ts
@@ -1,0 +1,69 @@
+import { getRelativeDateRange, resolveEventDateFilterValue } from "@/helpers/dateFilterHelper";
+
+describe("getRelativeDateRange()", () => {
+    const referenceDate = new Date(2026, 2, 25, 12, 30, 0, 0); // Wednesday, March 25, 2026
+
+    it("should resolve today", () => {
+        const result = getRelativeDateRange("today", referenceDate);
+        expect(result).toEqual({
+            start: new Date(2026, 2, 25, 0, 0, 0, 0),
+            end: new Date(2026, 2, 25, 23, 59, 59, 999)
+        });
+    })
+
+    it("should resolve this week using Monday as the first day", () => {
+        const result = getRelativeDateRange("this week", referenceDate);
+        expect(result).toEqual({
+            start: new Date(2026, 2, 23, 0, 0, 0, 0),
+            end: new Date(2026, 2, 29, 23, 59, 59, 999)
+        });
+    })
+
+    it("should resolve this month", () => {
+        const result = getRelativeDateRange("this month", referenceDate);
+        expect(result).toEqual({
+            start: new Date(2026, 2, 1, 0, 0, 0, 0),
+            end: new Date(2026, 2, 31, 23, 59, 59, 999)
+        });
+    })
+
+    it("should resolve this weekend", () => {
+        const result = getRelativeDateRange("this weekend", referenceDate);
+        expect(result).toEqual({
+            start: new Date(2026, 2, 28, 0, 0, 0, 0),
+            end: new Date(2026, 2, 29, 23, 59, 59, 999)
+        });
+    })
+
+    it("should support underscored and hyphenated aliases", () => {
+        const underscored = getRelativeDateRange("this_week", referenceDate);
+        const hyphenated = getRelativeDateRange("this-weekend", referenceDate);
+        expect(underscored).toEqual({
+            start: new Date(2026, 2, 23, 0, 0, 0, 0),
+            end: new Date(2026, 2, 29, 23, 59, 59, 999)
+        });
+        expect(hyphenated).toEqual({
+            start: new Date(2026, 2, 28, 0, 0, 0, 0),
+            end: new Date(2026, 2, 29, 23, 59, 59, 999)
+        });
+    })
+})
+
+describe("resolveEventDateFilterValue()", () => {
+    const referenceDate = new Date(2026, 2, 25, 12, 30, 0, 0);
+
+    it("should return a range for relative values", () => {
+        expect(resolveEventDateFilterValue("today", "eq", referenceDate)).toEqual({
+            start: new Date(2026, 2, 25, 0, 0, 0, 0),
+            end: new Date(2026, 2, 25, 23, 59, 59, 999)
+        });
+    })
+
+    it("should return a Date for explicit date strings", () => {
+        expect(resolveEventDateFilterValue("2026-03-25T08:15:00.000Z", "eq", referenceDate)).toEqual(new Date("2026-03-25T08:15:00.000Z"));
+    })
+
+    it("should throw on invalid date values", () => {
+        expect(() => resolveEventDateFilterValue("definitely-not-a-date", "eq", referenceDate)).toThrow("Invalid filter value definitely-not-a-date");
+    })
+})

--- a/app/tests/helpers/queryBuilder.test.ts
+++ b/app/tests/helpers/queryBuilder.test.ts
@@ -30,6 +30,38 @@ describe("buildFilterQuery() tests", () => {
             topics: { $regex: "meet", $options: 'i' }
         })
     })
+
+    it("Should expand date equality ranges into gte and lte operators", () => {
+        const dbFilter: Filter[] = [{
+            prefix: 'eq',
+            field: 'date',
+            value: {
+                start: new Date("2026-03-28T00:00:00.000Z"),
+                end: new Date("2026-03-28T23:59:59.999Z")
+            }
+        }]
+        const query = buildFilterQuery<Event>(dbFilter)
+        expect(query).toEqual({
+            date: {
+                $gte: new Date("2026-03-28T00:00:00.000Z"),
+                $lte: new Date("2026-03-28T23:59:59.999Z")
+            }
+        })
+    })
+
+    it("Should merge multiple operators for the same field", () => {
+        const dbFilter: Filter[] = [
+            { prefix: 'after', field: 'date', value: new Date("2026-03-28T00:00:00.000Z") },
+            { prefix: 'before', field: 'date', value: new Date("2026-03-30T00:00:00.000Z") }
+        ]
+        const query = buildFilterQuery<Event>(dbFilter)
+        expect(query).toEqual({
+            date: {
+                $gte: new Date("2026-03-28T00:00:00.000Z"),
+                $lte: new Date("2026-03-30T00:00:00.000Z")
+            }
+        })
+    })
 })
 describe("buildGeosearchQuery() tests", () => {
     it("Should return FilterQuery object", () => {

--- a/app/tests/middlewares/filterMiddleware.test.ts
+++ b/app/tests/middlewares/filterMiddleware.test.ts
@@ -59,6 +59,23 @@ describe("FilterMiddleware tests SUCCESS", () => {
         expect(next).toHaveBeenCalledTimes(1)
         expect(req.dbFilter).toEqual([{ prefix: 'before', value: new Date(inputDate), field: 'date' }])
     })
+    it("should populate DATE RANGE request.dbFilter parameter", () => {
+        jest.spyOn(Event, "getFilterableFields").mockReturnValue([{
+            field: 'date',
+            preprocess: (value: FilterValue) => value === "today"
+                ? { start: new Date("2026-03-28T00:00:00.000Z"), end: new Date("2026-03-28T23:59:59.999Z") }
+                : value
+        }])
+        req.query = { 'date_eq': "today" }
+        const middleware = filterMiddleware(Event)
+        middleware(req as Request, res as Response, next)
+        expect(next).toHaveBeenCalledTimes(1)
+        expect(req.dbFilter).toEqual([{
+            prefix: 'eq',
+            value: { start: new Date("2026-03-28T00:00:00.000Z"), end: new Date("2026-03-28T23:59:59.999Z") },
+            field: 'date'
+        }])
+    })
     it("should populate OPTIONS request.dbFilter parameter", () => {
         const inputTopic = "meet";
         jest.spyOn(Event, "getFilterableFields").mockReturnValue([{ field: 'topics', options: 'i' }])

--- a/app/tests/models/category/queries.test.ts
+++ b/app/tests/models/category/queries.test.ts
@@ -5,7 +5,7 @@ describe("getRoots() method", () => {
         const roots = await Category.find().getRoots();
 
         expect(roots).toBeInstanceOf(Array);
-        roots.forEach(async (root) => {
+        roots.forEach((root) => {
             expect(root.parent).toBeNull();
         });
     });

--- a/app/tests/models/category/statics.test.ts
+++ b/app/tests/models/category/statics.test.ts
@@ -3,12 +3,12 @@ import { Category } from "@/models/category/Category";
 describe("getTree() method", () => {
     beforeAll(async () => {
         const categories = await Category.find({ parent: null });
-        categories.forEach(async (category) => {
-            await Category.create({
+        await Promise.all(categories.map(category =>
+            Category.create({
                 title: category.title + " Subcategory",
                 parent: category._id
-            });
-        });
+            })
+        ));
     });
     afterAll(async () => {
         await Category.deleteMany({ parent: { $ne: null } });

--- a/app/tests/models/event/statics.test.ts
+++ b/app/tests/models/event/statics.test.ts
@@ -16,6 +16,16 @@ describe("getFilterableFields() method", () => {
             }
         ]);
     });
+
+    it("should resolve relative date aliases through the date preprocess function", () => {
+        const fields = getFilterableFields();
+        const dateField = fields.find(field => field.field === "date");
+        const result = dateField?.preprocess?.("this week", "eq");
+        expect(result).toEqual({
+            start: expect.any(Date),
+            end: expect.any(Date)
+        });
+    })
 });
 
 describe("getSortableFields() method", () => {

--- a/app/tests/requests/events.test.ts
+++ b/app/tests/requests/events.test.ts
@@ -20,6 +20,21 @@ import { STATUS_CONFIRMED } from "@/models/rsvp/utils";
 import { createFakeEvent } from "@tests/generators/event";
 import { getOneEvent, getOneUser } from "@tests/getters";
 
+function toUnixSeconds(value: Date): number {
+    return Math.floor(value.getTime() / 1000);
+}
+
+function atNoon(value: Date): Date {
+    return new Date(value.getFullYear(), value.getMonth(), value.getDate(), 12, 0, 0, 0);
+}
+
+function startOfWeek(value: Date): Date {
+    const result = new Date(value.getFullYear(), value.getMonth(), value.getDate());
+    const distanceFromMonday = (result.getDay() + 6) % 7;
+    result.setDate(result.getDate() - distanceFromMonday);
+    return result;
+}
+
 describe("GET /:eventId", () => {
     it("Should return event with author, categories and type data", async () => {
         const event = await getOneEvent();
@@ -61,6 +76,70 @@ describe("GET /:eventId", () => {
         expect(res.body.data).toHaveProperty('fieldErrors');
     })
 })
+
+describe("GET /api/event date filters", () => {
+    const titles = {
+        today: "Today Event",
+        tomorrow: "Tomorrow Event",
+        thisWeekend: "This Weekend Event",
+        nextWeek: "Next Week Event",
+        nextMonth: "Next Month Event"
+    };
+
+    beforeEach(async () => {
+        await Event.deleteMany({});
+
+        const now = new Date();
+        const weekStart = startOfWeek(now);
+        const thisWeekendDate = new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate() + 5, 12, 0, 0, 0);
+        const nextWeekDate = new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate() + 7, 12, 0, 0, 0);
+        const nextMonthDate = new Date(now.getFullYear(), now.getMonth() + 1, 1, 12, 0, 0, 0);
+
+        await createFakeEvent({ title: titles.today, date: toUnixSeconds(atNoon(now)) }, true);
+        await createFakeEvent({ title: titles.tomorrow, date: toUnixSeconds(new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 12, 0, 0, 0)) }, true);
+        await createFakeEvent({ title: titles.thisWeekend, date: toUnixSeconds(thisWeekendDate) }, true);
+        await createFakeEvent({ title: titles.nextWeek, date: toUnixSeconds(nextWeekDate) }, true);
+        await createFakeEvent({ title: titles.nextMonth, date: toUnixSeconds(nextMonthDate) }, true);
+    });
+
+    it("Should filter events for today", async () => {
+        const res = await request(app).get("/api/event").query({ date_eq: "today" }).send();
+        expect(res.statusCode).toBe(200);
+        const resultTitles = res.body.data.map((event: { title: string }) => event.title);
+        expect(resultTitles).toContain(titles.today);
+        expect(resultTitles).not.toContain(titles.tomorrow);
+        expect(resultTitles).not.toContain(titles.nextWeek);
+        expect(resultTitles).not.toContain(titles.nextMonth);
+    });
+
+    it("Should filter events for this week", async () => {
+        const res = await request(app).get("/api/event").query({ date_eq: "this week" }).send();
+        expect(res.statusCode).toBe(200);
+        const resultTitles = res.body.data.map((event: { title: string }) => event.title);
+        expect(resultTitles).toContain(titles.today);
+        expect(resultTitles).toContain(titles.thisWeekend);
+        expect(resultTitles).not.toContain(titles.nextWeek);
+        expect(resultTitles).not.toContain(titles.nextMonth);
+    });
+
+    it("Should filter events for this month", async () => {
+        const res = await request(app).get("/api/event").query({ date_eq: "this month" }).send();
+        expect(res.statusCode).toBe(200);
+        const resultTitles = res.body.data.map((event: { title: string }) => event.title);
+        expect(resultTitles).toContain(titles.today);
+        expect(resultTitles).not.toContain(titles.nextMonth);
+    });
+
+    it("Should filter events for this weekend", async () => {
+        const res = await request(app).get("/api/event").query({ date_eq: "this weekend" }).send();
+        expect(res.statusCode).toBe(200);
+        const resultTitles = res.body.data.map((event: { title: string }) => event.title);
+        expect(resultTitles).toContain(titles.thisWeekend);
+        expect(resultTitles).not.toContain(titles.nextWeek);
+        expect(resultTitles).not.toContain(titles.nextMonth);
+    });
+});
+
 describe("POST /attend", () => {
     let eventId: string;
     let userId: string;

--- a/app/tsconfig.build.json
+++ b/app/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "dist",
+    "tests",
+    "coverage",
+    "jest.config.ts"
+  ]
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -24,7 +24,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
     "module": "commonjs", /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./",                                     /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": ".", /* Specify the base directory to resolve non-relative module names. */
     "paths": {
@@ -61,7 +61,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */

--- a/docs/event-date-filter-flow.md
+++ b/docs/event-date-filter-flow.md
@@ -1,0 +1,145 @@
+# Event Date Filter Flow
+
+This document describes the runtime flow for event date filters on `GET /api/event`, for example:
+
+- `GET /api/event?date_eq=today`
+- `GET /api/event?date_eq=this_week`
+- `GET /api/event?date_before=2026-09-21`
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant R as event router
+    participant F as filterMiddleware(Event)
+    participant E as Event.getFilterableFields()
+    participant D as resolveEventDateFilterValue()
+    participant H as getRelativeDateRange()
+    participant L as requests/event/list.list()
+    participant U as buildRequestData()
+    participant S as eventService.list()
+    participant Q as buildFilterQuery()
+    participant M as MongoDB via Event.find()
+
+    C->>R: GET /api/event?date_eq=today
+    R->>F: invoke middleware chain
+    Note over R,F: Current runtime path uses the first router.get("/") registration
+    F->>E: getFilterableFields()
+    E-->>F: date field with preprocess(value, prefix)
+    F->>F: parseFilterKey("date_eq")
+    F->>F: parseFilterValue("today", "eq", preprocess)
+    F->>D: preprocess("today", "eq")
+    D->>H: getRelativeDateRange("today")
+
+    alt Relative alias matched
+        H-->>D: { start, end }
+        D-->>F: FilterRangeValue
+        F->>F: req.dbFilter = [{ field: "date", prefix: "eq", value: { start, end } }]
+        F->>L: next()
+        L->>U: buildRequestData(req)
+        U-->>L: { dbFilter, sort, pagination }
+        L->>S: list(data)
+        S->>Q: buildFilterQuery(data.dbFilter)
+        Q-->>S: { date: { $gte: start, $lte: end } }
+        S->>M: Event.find(query).sort(...).paginate(...)
+        M-->>S: matching events
+        S-->>L: events
+        L-->>C: 200 response
+    else Explicit date string
+        H-->>D: undefined
+        D->>D: new Date(value)
+        D-->>F: Date
+        F->>F: req.dbFilter = [{ field: "date", prefix: "eq|before|after|...", value: Date }]
+        F->>L: next()
+        L->>U: buildRequestData(req)
+        L->>S: list(data)
+        S->>Q: buildFilterQuery(data.dbFilter)
+        Q-->>S: Mongo query using $eq / $lte / $gte
+        S->>M: Event.find(query).sort(...).paginate(...)
+        M-->>S: matching events
+        S-->>L: events
+        L-->>C: 200 response
+    else Invalid value
+        H-->>D: undefined
+        D->>D: new Date(value) => Invalid Date
+        D-->>F: throw Error("Invalid filter value ...")
+        F-->>C: 400 response
+    end
+```
+
+## Method Call Order
+
+For a request like `GET /api/event?date_eq=today`, the methods are called in this order:
+
+1. `router.get("/", [paginateMiddleware, filterMiddleware(Event)], list)` matches the request.
+2. `filterMiddleware(Event)` runs and asks the model for allowed filters through `Event.getFilterableFields()`.
+3. `parseFilterKey()` splits `date_eq` into:
+   - field: `date`
+   - operator: `eq`
+4. `parseFilterValue()` validates the raw query value and calls the `date` field preprocess function from `getFilterableFields()`.
+5. The preprocess function calls `resolveEventDateFilterValue(value, prefix)`.
+6. `resolveEventDateFilterValue()` tries `getRelativeDateRange(value)` first.
+7. If the value is a relative alias such as `today`, `this week`, `this month`, or `this weekend`, `getRelativeDateRange()` returns `{ start, end }`.
+8. If the value is not a relative alias, `resolveEventDateFilterValue()` falls back to `new Date(value)`.
+9. `filterMiddleware` stores the parsed filter in `req.dbFilter`.
+10. `list()` builds a request DTO through `buildRequestData(req)`.
+11. `eventService.list(data)` converts `req.dbFilter` into a Mongo query with `buildFilterQuery(data.dbFilter)`.
+12. `buildFilterQuery()` expands date ranges like `{ start, end }` into Mongo operators:
+    - `eq` => `{ $gte: start, $lte: end }`
+    - `after` or `min` => `{ $gte: start }`
+    - `before` or `max` => `{ $lte: end }`
+13. `Event.find(query).sort(...).paginate(...)` runs against MongoDB.
+14. The list handler serializes the events with `event.toJSON()` and sends the HTTP response.
+
+## Relative Date Resolution
+
+The relative date handling lives in `app/src/helpers/dateFilterHelper.ts`.
+
+- `today` resolves to the current day from `00:00:00.000` through `23:59:59.999`
+- `this week` resolves from Monday start through Sunday end
+- `this month` resolves from the first day of the month through the last millisecond before the next month
+- `this weekend` resolves from Saturday start through Sunday end
+- aliases with underscores or hyphens are normalized, for example `this_week` and `this-weekend`
+
+Internally, the helper builds an inclusive range by computing an exclusive end and then subtracting `1ms`.
+
+## Data Shape at Each Step
+
+Raw query string:
+
+```txt
+date_eq=today
+```
+
+`req.dbFilter` after `filterMiddleware`:
+
+```ts
+[
+  {
+    field: "date",
+    prefix: "eq",
+    value: {
+      start: Date,
+      end: Date
+    }
+  }
+]
+```
+
+Mongo query after `buildFilterQuery()`:
+
+```ts
+{
+  date: {
+    $gte: start,
+    $lte: end
+  }
+}
+```
+
+## Notes
+
+- There are two `router.get("/")` registrations in `app/src/routes/event.ts`. The first one is the effective path for this flow because it handles the response and does not call `next()`, so the later `GET /` route is not reached during a normal date-filter request.
+- Date filter behavior is covered by request tests, middleware tests, helper tests, and query builder tests.


### PR DESCRIPTION
## What changed

This PR extends event date filtering to support relative values such as `today`, `this week`, `this month`, and `this weekend`.

It adds a dedicated date filter helper, wires event date preprocessing through that helper, and updates the query builder so a single filter can expand into Mongo date ranges and same-field operators can be merged safely.

## Why

The existing event filtering only supported direct date values. That made common product-facing filters harder to express and pushed relative date logic out of the API layer.

This change makes those filters first-class and keeps the translation from friendly values to database predicates in one place.

## Impact

Users can now query events with relative date filters like `date_eq=today` and related values for the current week, month, and weekend.

Developers also get safer TypeScript support for range-shaped filters, plus targeted tests covering helper behavior, middleware parsing, and query generation.

## Build output cleanup

Because `tsc` was emitting `.js` files next to the TypeScript sources, this PR also updates the app TypeScript config to emit into `dist/` and ignores generated JS artifacts in the app gitignore.

## Validation

- `npm run build`
- `npm test -- --config jest.config.ts --runInBand tests/helpers/dateFilterHelper.test.ts tests/helpers/queryBuilder.test.ts tests/middlewares/filterMiddleware.test.ts tests/models/event/statics.test.ts`
