### PR TITLE
[codex] Fix event date field handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,13 @@ cd app && npm run lint
 - Models: `app/src/models/`
 - Schemas and validation: `app/src/schemas/`
 
+### Model Organization
+
+- Keep each model entry file focused on schema definition, indexes, `toJSON` transforms, plugin wiring, and importing related model helpers.
+- Put model-specific logic next to the model in the same directory, following the existing split such as `hooks.ts`, `methods.ts`, `queries.ts`, `statics.ts`, `utils.ts`, and `validators.ts`.
+- Use `app/src/helpers/` for shared cross-model helpers. If a function is reusable outside one model domain, prefer a helper over placing it in a model file.
+- Mirror this structure in tests: shared helpers belong in `app/tests/helpers/`, and model-specific utilities or behavior belong in `app/tests/models/<model>/`.
+
 ### Tests
 
 - Request tests: `app/tests/requests/`

--- a/app/src/helpers/dateHelper.ts
+++ b/app/src/helpers/dateHelper.ts
@@ -1,0 +1,3 @@
+export function toUnixSeconds(value: Date): number {
+    return Math.floor(value.getTime() / 1000);
+}

--- a/app/src/models/event/Event.ts
+++ b/app/src/models/event/Event.ts
@@ -36,6 +36,37 @@ export type HydratedEvent = HydratedDocument<IEvent>;
 
 interface EventModelType extends Model<IEvent, PaginateQueryHelper<IEvent>, object>, Filterable, Sortable { }
 
+function normalizeEventDate(value: Date | number | string): Date {
+    if (value instanceof Date) {
+        return value;
+    }
+
+    if (typeof value === "number") {
+        const milliseconds = Math.abs(value) >= 1e12 ? value : value * 1000;
+        return new Date(milliseconds);
+    }
+
+    if (typeof value === "string") {
+        const trimmedValue = value.trim();
+
+        if (/^-?\d+$/.test(trimmedValue)) {
+            return normalizeEventDate(Number(trimmedValue));
+        }
+
+        return new Date(trimmedValue);
+    }
+
+    return value;
+}
+
+function toUnixSeconds(value: unknown): number | unknown {
+    if (!(value instanceof Date)) {
+        return value;
+    }
+
+    return Math.floor(value.getTime() / 1000);
+}
+
 export const EventSchema = new Schema<IEvent, Model<IEvent>, object, PaginateQueryHelper<IEvent>>(
     {
         title: {
@@ -48,7 +79,7 @@ export const EventSchema = new Schema<IEvent, Model<IEvent>, object, PaginateQue
         },
         date: {
             type: Date,
-            set: (v: number) => new Date(v * 1000),
+            set: normalizeEventDate,
             required: true
         },
         fullAddress: {
@@ -129,12 +160,19 @@ EventSchema.set('toJSON', {
     virtuals: false,
     versionKey: false,
     transform: (_, ret) => {
-        if ('updatedAt' in ret) {
-            delete ret.updatedAt;
-        }
-        ret.imageUrl = getConfigValue('HOST') + '/' + ret.imageUrl
+        const transformedRet = ret as unknown as Record<string, unknown> & {
+            date: unknown;
+            imageUrl: string;
+        };
 
-        return ret;
+        if ('updatedAt' in transformedRet) {
+            delete transformedRet.updatedAt;
+        }
+
+        transformedRet.date = toUnixSeconds(transformedRet.date);
+        transformedRet.imageUrl = getConfigValue('HOST') + '/' + transformedRet.imageUrl
+
+        return transformedRet;
     }
 })
 
@@ -159,5 +197,3 @@ EventSchema.post("save", postSaveHook)
 EventSchema.plugin(paginatePlugin<IEvent>);
 
 export const Event = mongoose.model<IEvent, EventModelType>("Event", EventSchema)
-
-

--- a/app/src/models/event/Event.ts
+++ b/app/src/models/event/Event.ts
@@ -2,12 +2,14 @@ import mongoose, { HydratedDocument, Schema, Types, SchemaTypes, Model } from "m
 import { type Filterable } from "@/types/Filter";
 import { type CurrencyCode } from "currency-codes-ts/dist/types";
 import { getConfigValue } from "@/helpers/configHelper";
+import { toUnixSeconds } from "@/helpers/dateHelper";
 import { type Sortable } from "@/types/Sort";
 import { paginatePlugin, type PaginateQueryHelper } from "@/models/plugins/paginate";
 import messages from "@/constants/errorMessages";
 import { getFilterableFields, getSortableFields } from "@/models/event/statics";
 import { categoriesValidator, typeValidator } from "@/models/event/validators";
 import { postSaveHook, preSaveHook } from "@/models/event/hooks";
+import { normalizeEventDate } from "@/models/event/utils";
 
 export interface IEvent {
     _id: Types.ObjectId;
@@ -35,37 +37,6 @@ export interface IEvent {
 export type HydratedEvent = HydratedDocument<IEvent>;
 
 interface EventModelType extends Model<IEvent, PaginateQueryHelper<IEvent>, object>, Filterable, Sortable { }
-
-function normalizeEventDate(value: Date | number | string): Date {
-    if (value instanceof Date) {
-        return value;
-    }
-
-    if (typeof value === "number") {
-        const milliseconds = Math.abs(value) >= 1e12 ? value : value * 1000;
-        return new Date(milliseconds);
-    }
-
-    if (typeof value === "string") {
-        const trimmedValue = value.trim();
-
-        if (/^-?\d+$/.test(trimmedValue)) {
-            return normalizeEventDate(Number(trimmedValue));
-        }
-
-        return new Date(trimmedValue);
-    }
-
-    return value;
-}
-
-function toUnixSeconds(value: unknown): number | unknown {
-    if (!(value instanceof Date)) {
-        return value;
-    }
-
-    return Math.floor(value.getTime() / 1000);
-}
 
 export const EventSchema = new Schema<IEvent, Model<IEvent>, object, PaginateQueryHelper<IEvent>>(
     {
@@ -169,7 +140,9 @@ EventSchema.set('toJSON', {
             delete transformedRet.updatedAt;
         }
 
-        transformedRet.date = toUnixSeconds(transformedRet.date);
+        if (transformedRet.date instanceof Date) {
+            transformedRet.date = toUnixSeconds(transformedRet.date);
+        }
         transformedRet.imageUrl = getConfigValue('HOST') + '/' + transformedRet.imageUrl
 
         return transformedRet;

--- a/app/src/models/event/utils.ts
+++ b/app/src/models/event/utils.ts
@@ -1,0 +1,22 @@
+export function normalizeEventDate(value: Date | number | string): Date {
+    if (value instanceof Date) {
+        return value;
+    }
+
+    if (typeof value === "number") {
+        const milliseconds = Math.abs(value) >= 1e12 ? value : value * 1000;
+        return new Date(milliseconds);
+    }
+
+    if (typeof value === "string") {
+        const trimmedValue = value.trim();
+
+        if (/^-?\d+$/.test(trimmedValue)) {
+            return normalizeEventDate(Number(trimmedValue));
+        }
+
+        return new Date(trimmedValue);
+    }
+
+    return value;
+}

--- a/app/tests/helpers/dateHelper.test.ts
+++ b/app/tests/helpers/dateHelper.test.ts
@@ -1,0 +1,7 @@
+import { toUnixSeconds } from "@/helpers/dateHelper";
+
+describe("toUnixSeconds()", () => {
+    it("should convert a Date into unix seconds", () => {
+        expect(toUnixSeconds(new Date("2026-03-27T12:13:23.000Z"))).toBe(1774613603);
+    });
+});

--- a/app/tests/models/event/model.test.ts
+++ b/app/tests/models/event/model.test.ts
@@ -1,0 +1,21 @@
+import { Event } from "@/models/event/Event";
+import { createFakeEvent } from "@tests/generators/event";
+
+describe("Event model date handling", () => {
+    beforeEach(async () => {
+        await Event.deleteMany({});
+    });
+
+    it("should preserve Date inputs and serialize them as unix seconds", async () => {
+        const eventDate = new Date("2026-03-27T12:13:23.000Z");
+        const eventData = await createFakeEvent();
+
+        const event = await Event.create({
+            ...eventData,
+            date: eventDate
+        } as const);
+
+        expect(event.date.toISOString()).toBe(eventDate.toISOString());
+        expect(event.toJSON().date).toBe(Math.floor(eventDate.getTime() / 1000));
+    });
+});

--- a/app/tests/models/event/utils.test.ts
+++ b/app/tests/models/event/utils.test.ts
@@ -1,0 +1,25 @@
+import { normalizeEventDate } from "@/models/event/utils";
+
+describe("normalizeEventDate()", () => {
+    it("should keep Date inputs unchanged", () => {
+        const value = new Date("2026-03-27T12:13:23.000Z");
+
+        expect(normalizeEventDate(value)).toBe(value);
+    });
+
+    it("should convert unix-second numbers to Date", () => {
+        expect(normalizeEventDate(1774613603).toISOString()).toBe("2026-03-27T12:13:23.000Z");
+    });
+
+    it("should convert millisecond numbers to Date", () => {
+        expect(normalizeEventDate(1774613603000).toISOString()).toBe("2026-03-27T12:13:23.000Z");
+    });
+
+    it("should convert numeric strings to Date", () => {
+        expect(normalizeEventDate("1774613603").toISOString()).toBe("2026-03-27T12:13:23.000Z");
+    });
+
+    it("should convert ISO strings to Date", () => {
+        expect(normalizeEventDate("2026-03-27T12:13:23.000Z").toISOString()).toBe("2026-03-27T12:13:23.000Z");
+    });
+});

--- a/app/tests/requests/events.test.ts
+++ b/app/tests/requests/events.test.ts
@@ -44,6 +44,7 @@ describe("GET /:eventId", () => {
         if (!event) {
             throw new Error("No events in DB!");
         }
+        const expectedDate = Math.floor(event.date.getTime() / 1000);
         const res = await request(app).get(`/api/event/${event._id.toString()}`).send();
         expect(res.statusCode).toBe(200);
         expect(res.body).toHaveProperty('data');
@@ -60,6 +61,8 @@ describe("GET /:eventId", () => {
         expect(res.body.data.type).toHaveProperty('title');
         expect(res.body.data).toHaveProperty('description');
         expect(res.body.data).toHaveProperty('date');
+        expect(res.body.data.date).toBe(expectedDate);
+        expect(typeof res.body.data.date).toBe("number");
         expect(res.body.data).toHaveProperty('fullAddress');
         expect(res.body.data).toHaveProperty('imageUrl');
         expect(res.body.data).toHaveProperty('maxAttendees');


### PR DESCRIPTION
## What changed
- fixed `Event.date` normalization so the model safely accepts Unix-second inputs and real `Date` objects without corrupting stored values
- serialized `event.date` as a Unix timestamp in `Event` JSON responses to match the API contract
- added regression coverage for direct model creation with a `Date` input and for the event fetch response shape
- tightened the `toJSON` transform typing after review feedback so `updatedAt` is not part of the explicit transformed shape

## Why it changed
Event creation/update already treated `date` as a Unix timestamp at the API boundary, but the Mongoose setter assumed every incoming value was Unix seconds. When internal code paths such as seeders passed a real `Date`, the setter multiplied a millisecond value by `1000`, which could produce corrupted dates like `+057970-10-23T00:00:00.000Z`.

## Impact
Clients now receive `event.date` as a Unix timestamp number, consistent with the request schema, and internal model callers can safely pass either Unix seconds or `Date` objects.

## Validation
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand tests/models/event/model.test.ts tests/requests/events.test.ts`