### PR TITLE
Update seeded event dates for current month

### DIFF
--- a/app/src/seeders/events.seeder.ts
+++ b/app/src/seeders/events.seeder.ts
@@ -2,6 +2,139 @@ import { Event } from "@/models/event/Event";
 import { EventType } from "@/models/EventType";
 import { User } from "@/models/user/User";
 
+const EVENT_HOURS = [18, 19, 20, 9, 16, 17, 12, 15, 14, 21];
+
+type RandomFn = () => number;
+
+function startOfWeek(value: Date): Date {
+    const result = new Date(value.getFullYear(), value.getMonth(), value.getDate());
+    const distanceFromMonday = (result.getDay() + 6) % 7;
+    result.setDate(result.getDate() - distanceFromMonday);
+    return result;
+}
+
+function isSameDay(left: Date, right: Date): boolean {
+    return left.getFullYear() === right.getFullYear()
+        && left.getMonth() === right.getMonth()
+        && left.getDate() === right.getDate();
+}
+
+function isSameMonth(value: Date, referenceDate: Date): boolean {
+    return value.getFullYear() === referenceDate.getFullYear()
+        && value.getMonth() === referenceDate.getMonth();
+}
+
+function buildDate(referenceDate: Date, dayOfMonth: number, hours: number): Date {
+    return new Date(referenceDate.getFullYear(), referenceDate.getMonth(), dayOfMonth, hours, 0, 0, 0);
+}
+
+function getWeekDates(referenceDate: Date): Date[] {
+    const weekStart = startOfWeek(referenceDate);
+    return Array.from({ length: 7 }, (_, offset) => {
+        const date = new Date(weekStart);
+        date.setDate(weekStart.getDate() + offset);
+        return date;
+    });
+}
+
+function shuffle<T>(values: T[], random: RandomFn): T[] {
+    const result = [...values];
+    for (let index = result.length - 1; index > 0; index -= 1) {
+        const swapIndex = Math.floor(random() * (index + 1));
+        [result[index], result[swapIndex]] = [result[swapIndex], result[index]];
+    }
+    return result;
+}
+
+function pickThisWeekDate(referenceDate: Date): Date {
+    const weekDates = getWeekDates(referenceDate);
+    const nextDate = weekDates.find(date => !isSameDay(date, referenceDate) && date > referenceDate);
+    if (nextDate) {
+        return new Date(nextDate.getFullYear(), nextDate.getMonth(), nextDate.getDate());
+    }
+
+    const previousDate = [...weekDates].reverse().find(date => !isSameDay(date, referenceDate));
+    if (previousDate) {
+        return new Date(previousDate.getFullYear(), previousDate.getMonth(), previousDate.getDate());
+    }
+
+    throw new Error("Could not build a distinct event date for this week");
+}
+
+function getWeekDaysInCurrentMonth(referenceDate: Date): number[] {
+    return getWeekDates(referenceDate)
+        .filter(date => isSameMonth(date, referenceDate))
+        .map(date => date.getDate());
+}
+
+function pickThisMonthDay(referenceDate: Date, weekDaysInCurrentMonth: number[]): number {
+    const daysInMonth = new Date(referenceDate.getFullYear(), referenceDate.getMonth() + 1, 0).getDate();
+    const weekDaySet = new Set(weekDaysInCurrentMonth);
+    const daysOutsideCurrentWeek = Array.from({ length: daysInMonth }, (_, index) => index + 1)
+        .filter(day => !weekDaySet.has(day));
+
+    const preferredFutureDay = daysOutsideCurrentWeek.find(day => day > referenceDate.getDate());
+    if (preferredFutureDay) {
+        return preferredFutureDay;
+    }
+
+    const fallbackPastDay = [...daysOutsideCurrentWeek].reverse().find(day => day < referenceDate.getDate());
+    if (fallbackPastDay) {
+        return fallbackPastDay;
+    }
+
+    const fallbackDay = Array.from({ length: daysInMonth }, (_, index) => index + 1)
+        .find(day => day !== referenceDate.getDate());
+    if (fallbackDay) {
+        return fallbackDay;
+    }
+
+    throw new Error("Could not build a distinct event date for this month");
+}
+
+export function buildSeedEventDates(
+    referenceDate: Date = new Date(),
+    totalEvents: number = EVENT_HOURS.length,
+    random: RandomFn = Math.random
+): Date[] {
+    if (totalEvents < 3) {
+        throw new Error("At least three seed event dates are required");
+    }
+
+    const todayDate = new Date(
+        referenceDate.getFullYear(),
+        referenceDate.getMonth(),
+        referenceDate.getDate(),
+        EVENT_HOURS[2],
+        0,
+        0,
+        0
+    );
+
+    const thisWeekDate = pickThisWeekDate(referenceDate);
+    thisWeekDate.setHours(EVENT_HOURS[1], 0, 0, 0);
+
+    const weekDaysInCurrentMonth = getWeekDaysInCurrentMonth(referenceDate);
+    const thisMonthDay = pickThisMonthDay(referenceDate, weekDaysInCurrentMonth);
+    const thisMonthDate = buildDate(referenceDate, thisMonthDay, EVENT_HOURS[0]);
+
+    const excludedMonthDays = new Set<number>([...weekDaysInCurrentMonth, thisMonthDay]);
+    const daysInMonth = new Date(referenceDate.getFullYear(), referenceDate.getMonth() + 1, 0).getDate();
+    const availableMonthDays = Array.from({ length: daysInMonth }, (_, index) => index + 1)
+        .filter(day => !excludedMonthDays.has(day));
+
+    const remainingEvents = totalEvents - 3;
+    if (availableMonthDays.length < remainingEvents) {
+        throw new Error("Not enough days outside the current week to seed events for this month");
+    }
+
+    const randomMonthDates = shuffle(availableMonthDays, random)
+        .slice(0, remainingEvents)
+        .map((day, index) => buildDate(referenceDate, day, EVENT_HOURS[(index + 3) % EVENT_HOURS.length]));
+
+    return [thisMonthDate, thisWeekDate, todayDate, ...randomMonthDates];
+}
+
 export async function seed() {
     const eventTypes = await EventType.find({}, { _id: 1 }).lean();
 
@@ -21,12 +154,13 @@ export async function seed() {
     const randomEventTypeId = () =>
         eventTypes[Math.floor(Math.random() * eventTypes.length)]._id;
 
+    const eventDates = buildSeedEventDates();
 
     const events = [
         {
             title: "Tech Startup Networking Night",
             description: "An evening for founders, developers, and investors to connect and share ideas.",
-            date: new Date("2025-02-10T18:30:00Z"),
+            date: eventDates[0],
             fullAddress: "123 Market St, San Francisco, CA 94103, USA",
             location: {
                 type: "Point",
@@ -43,7 +177,7 @@ export async function seed() {
         {
             title: "Weekend Yoga in the Park",
             description: "Relaxing outdoor yoga session suitable for all levels.",
-            date: new Date("2025-03-02T09:00:00Z"),
+            date: eventDates[1],
             fullAddress: "Golden Gate Park, San Francisco, CA, USA",
             location: {
                 type: "Point",
@@ -60,7 +194,7 @@ export async function seed() {
         {
             title: "JavaScript Advanced Workshop",
             description: "Deep dive into modern JavaScript patterns and performance tips.",
-            date: new Date("2025-04-15T16:00:00Z"),
+            date: eventDates[2],
             fullAddress: "456 Howard St, San Francisco, CA 94105, USA",
             location: {
                 type: "Point",
@@ -77,7 +211,7 @@ export async function seed() {
         {
             title: "Local Artists Art Exhibition",
             description: "Showcasing contemporary artwork from local artists.",
-            date: new Date("2025-05-20T17:00:00Z"),
+            date: eventDates[3],
             fullAddress: "789 Mission St, San Francisco, CA 94103, USA",
             location: {
                 type: "Point",
@@ -94,7 +228,7 @@ export async function seed() {
         {
             title: "Food Truck Festival",
             description: "Taste dishes from the best food trucks in the city.",
-            date: new Date("2025-06-08T12:00:00Z"),
+            date: eventDates[4],
             fullAddress: "Pier 39, San Francisco, CA 94133, USA",
             location: {
                 type: "Point",
@@ -111,7 +245,7 @@ export async function seed() {
         {
             title: "Photography City Walk",
             description: "Guided photo walk through iconic city locations.",
-            date: new Date("2025-07-12T15:00:00Z"),
+            date: eventDates[5],
             fullAddress: "Ferry Building, San Francisco, CA 94111, USA",
             location: {
                 type: "Point",
@@ -128,7 +262,7 @@ export async function seed() {
         {
             title: "Live Jazz Night",
             description: "Enjoy live jazz music from talented local musicians.",
-            date: new Date("2025-08-03T20:00:00Z"),
+            date: eventDates[6],
             fullAddress: "321 Jazz Alley, San Francisco, CA 94102, USA",
             location: {
                 type: "Point",
@@ -145,7 +279,7 @@ export async function seed() {
         {
             title: "Startup Pitch Competition",
             description: "Early-stage startups pitch to a panel of investors.",
-            date: new Date("2025-09-18T17:30:00Z"),
+            date: eventDates[7],
             fullAddress: "901 Howard St, San Francisco, CA 94103, USA",
             location: {
                 type: "Point",
@@ -162,7 +296,7 @@ export async function seed() {
         {
             title: "Cooking Masterclass: Italian Cuisine",
             description: "Hands-on cooking class focused on classic Italian dishes.",
-            date: new Date("2025-10-05T18:00:00Z"),
+            date: eventDates[8],
             fullAddress: "654 Culinary Ave, San Francisco, CA 94107, USA",
             location: {
                 type: "Point",
@@ -179,7 +313,7 @@ export async function seed() {
         {
             title: "New Year Rooftop Party",
             description: "Celebrate the new year with music, drinks, and city views.",
-            date: new Date("2025-12-31T21:00:00Z"),
+            date: eventDates[9],
             fullAddress: "999 Skyline Blvd, San Francisco, CA 94105, USA",
             location: {
                 type: "Point",

--- a/app/tests/seeders/events.seeder.test.ts
+++ b/app/tests/seeders/events.seeder.test.ts
@@ -1,0 +1,69 @@
+import { buildSeedEventDates } from "@/seeders/events.seeder";
+
+function startOfDay(value: Date): Date {
+    return new Date(value.getFullYear(), value.getMonth(), value.getDate(), 0, 0, 0, 0);
+}
+
+function startOfWeek(value: Date): Date {
+    const result = startOfDay(value);
+    const distanceFromMonday = (result.getDay() + 6) % 7;
+    result.setDate(result.getDate() - distanceFromMonday);
+    return result;
+}
+
+function endOfWeek(value: Date): Date {
+    const result = startOfWeek(value);
+    result.setDate(result.getDate() + 6);
+    result.setHours(23, 59, 59, 999);
+    return result;
+}
+
+function isSameDay(left: Date, right: Date): boolean {
+    return left.getFullYear() === right.getFullYear()
+        && left.getMonth() === right.getMonth()
+        && left.getDate() === right.getDate();
+}
+
+function isSameMonth(value: Date, referenceDate: Date): boolean {
+    return value.getFullYear() === referenceDate.getFullYear()
+        && value.getMonth() === referenceDate.getMonth();
+}
+
+function toDateKey(value: Date): string {
+    return `${value.getFullYear()}-${value.getMonth()}-${value.getDate()}`;
+}
+
+describe("buildSeedEventDates()", () => {
+    it("should seed one date today, one elsewhere this week, and the rest in the current month", () => {
+        const referenceDate = new Date(2026, 2, 25, 10, 30, 0, 0);
+        const dates = buildSeedEventDates(referenceDate, 10, () => 0.35);
+        const [thisMonthDate, thisWeekDate, todayDate, ...randomMonthDates] = dates;
+        const weekStart = startOfWeek(referenceDate);
+        const weekEnd = endOfWeek(referenceDate);
+
+        expect(dates).toHaveLength(10);
+        expect(isSameDay(todayDate, referenceDate)).toBe(true);
+        expect(thisWeekDate >= weekStart).toBe(true);
+        expect(thisWeekDate <= weekEnd).toBe(true);
+        expect(isSameDay(thisWeekDate, referenceDate)).toBe(false);
+        expect(isSameMonth(thisMonthDate, referenceDate)).toBe(true);
+        expect(thisMonthDate < weekStart || thisMonthDate > weekEnd).toBe(true);
+        expect(randomMonthDates).toHaveLength(7);
+        expect(randomMonthDates.every(date => isSameMonth(date, referenceDate))).toBe(true);
+        expect(randomMonthDates.every(date => date < weekStart || date > weekEnd)).toBe(true);
+        expect(new Set(dates.map(toDateKey)).size).toBe(dates.length);
+    });
+
+    it("should keep the current-week date valid when the week crosses a month boundary", () => {
+        const referenceDate = new Date(2026, 2, 1, 10, 30, 0, 0);
+        const [, thisWeekDate, todayDate, ...randomMonthDates] = buildSeedEventDates(referenceDate, 10, () => 0.5);
+        const weekStart = startOfWeek(referenceDate);
+        const weekEnd = endOfWeek(referenceDate);
+
+        expect(isSameDay(todayDate, referenceDate)).toBe(true);
+        expect(thisWeekDate >= weekStart).toBe(true);
+        expect(thisWeekDate <= weekEnd).toBe(true);
+        expect(isSameDay(thisWeekDate, referenceDate)).toBe(false);
+        expect(randomMonthDates.every(date => isSameMonth(date, referenceDate))).toBe(true);
+    });
+});


### PR DESCRIPTION
## What changed
- replaced fixed 2025 event seed dates with dynamic dates relative to the current calendar
- guaranteed one seeded event today, one elsewhere in the current week, one elsewhere in the current month, and randomized the remaining dates within the current month
- added a targeted seeder test covering the standard case and a month-boundary week

## Why it changed
- the events seeder now produces data that stays relevant for date-based filtering and testing without needing manual date updates

## User or developer impact
- developers get fresher seeded event data for local work and automated tests
- date-filter flows have reliable seed coverage for today, this week, and this month

## Verification
- cd app && npm run lint
- cd app && npm run build
- cd app && npm test -- --config jest.config.ts --runInBand tests/seeders/events.seeder.test.ts