### PR TITLE
Add weekly Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
## What changed
- add a new `.github/dependabot.yml` configuration
- enable weekly Friday Dependabot PRs for `npm` dependencies in `/app`
- enable weekly Friday Dependabot PRs for GitHub Actions dependencies at the repo root

## Why it changed
- automate dependency update PRs on a predictable weekly cadence

## User or developer impact
- dependency updates will now arrive as GitHub PRs once a week on Fridays