### PR TITLE
[codex] Improve event seed realism

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,7 +1,9 @@
 .env
 node_modules/
 logs/
-uploads/
+uploads/*
+!uploads/seed-events/
+!uploads/seed-events/*.svg
 .DS_Store
 docs
 coverage

--- a/app/src/seeders/events.seeder.ts
+++ b/app/src/seeders/events.seeder.ts
@@ -1,5 +1,6 @@
 import { Event } from "@/models/event/Event";
 import { EventType } from "@/models/EventType";
+import { Category } from "@/models/category/Category";
 import { User } from "@/models/user/User";
 
 const EVENT_HOURS = [18, 19, 20, 9, 16, 17, 12, 15, 14, 21];
@@ -142,6 +143,12 @@ export async function seed() {
         throw new Error("No event types found");
     }
 
+    const categories = await Category.find({}, { _id: 1 }).sort({ _id: 1 }).lean();
+
+    if (!categories.length) {
+        throw new Error("No categories found");
+    }
+
     const users = await User.find({}, { _id: 1 }).lean();
 
     if (!users.length) {
@@ -153,6 +160,8 @@ export async function seed() {
 
     const randomEventTypeId = () =>
         eventTypes[Math.floor(Math.random() * eventTypes.length)]._id;
+
+    const getSeedImageUrl = (fileName: string) => `uploads/seed-events/${fileName}`;
 
     const eventDates = buildSeedEventDates();
 
@@ -166,11 +175,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.4194, 37.7749],
             },
-            imageUrl: "https://example.com/images/startup-networking.jpg",
+            imageUrl: getSeedImageUrl("city-connections.svg"),
             maxAttendees: 120,
             fee: {
                 amount: 25,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -183,11 +192,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.4862, 37.7694],
             },
-            imageUrl: "https://example.com/images/yoga-park.jpg",
+            imageUrl: getSeedImageUrl("outdoor-gathering.svg"),
             maxAttendees: 50,
             fee: {
                 amount: 10,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -200,11 +209,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.3977, 37.7897],
             },
-            imageUrl: "https://example.com/images/js-workshop.jpg",
+            imageUrl: getSeedImageUrl("creative-session.svg"),
             maxAttendees: 80,
             fee: {
                 amount: 99,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -217,11 +226,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.4041, 37.7841],
             },
-            imageUrl: "https://example.com/images/art-exhibition.jpg",
+            imageUrl: getSeedImageUrl("creative-session.svg"),
             maxAttendees: 200,
             fee: {
                 amount: 15,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -234,11 +243,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.4107, 37.8087],
             },
-            imageUrl: "https://example.com/images/food-truck-festival.jpg",
-            maxAttendees: 500,
+            imageUrl: getSeedImageUrl("outdoor-gathering.svg"),
+            maxAttendees: 200,
             fee: {
                 amount: 5,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -251,11 +260,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.3933, 37.7955],
             },
-            imageUrl: "https://example.com/images/photo-walk.jpg",
+            imageUrl: getSeedImageUrl("city-connections.svg"),
             maxAttendees: 30,
             fee: {
                 amount: 20,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -268,11 +277,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.4181, 37.7793],
             },
-            imageUrl: "https://example.com/images/jazz-night.jpg",
+            imageUrl: getSeedImageUrl("city-connections.svg"),
             maxAttendees: 100,
             fee: {
                 amount: 30,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -285,11 +294,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.4009, 37.7827],
             },
-            imageUrl: "https://example.com/images/pitch-competition.jpg",
+            imageUrl: getSeedImageUrl("creative-session.svg"),
             maxAttendees: 150,
             fee: {
                 amount: 40,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -302,11 +311,11 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.3949, 37.7648],
             },
-            imageUrl: "https://example.com/images/italian-cooking.jpg",
+            imageUrl: getSeedImageUrl("creative-session.svg"),
             maxAttendees: 25,
             fee: {
                 amount: 75,
-                currence: "USD",
+                currency: "USD",
             },
             active: true
         },
@@ -319,17 +328,18 @@ export async function seed() {
                 type: "Point",
                 coordinates: [-122.3999, 37.7886],
             },
-            imageUrl: "https://example.com/images/new-year-party.jpg",
-            maxAttendees: 300,
+            imageUrl: getSeedImageUrl("city-connections.svg"),
+            maxAttendees: 200,
             fee: {
                 amount: 120,
-                currence: "USD",
+                currency: "USD",
             },
             active: false
         },
     ];
-    const eventsToInsert = events.map(event => ({
+    const eventsToInsert = events.map((event, index) => ({
         ...event,
+        categories: [categories[index % categories.length]._id],
         author: randomUserId(),
         type: randomEventTypeId(),
     }));

--- a/app/uploads/seed-events/city-connections.svg
+++ b/app/uploads/seed-events/city-connections.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title id="title">City connections placeholder</title>
+<desc id="desc">Abstract city-themed placeholder for seeded events.</desc>
+<defs>
+<linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+<stop offset="0%" stop-color="#17324d"/>
+<stop offset="100%" stop-color="#3b7a9e"/>
+</linearGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<circle cx="180" cy="140" r="74" fill="#f0c674" opacity="0.9"/>
+<circle cx="1020" cy="140" r="54" fill="#f5efe6" opacity="0.35"/>
+<path d="M0 520 L170 430 L300 470 L440 360 L610 430 L770 290 L910 365 L1040 250 L1200 330 L1200 630 L0 630 Z" fill="#0f2236" opacity="0.9"/>
+<path d="M95 630 L95 370 L180 370 L180 630 Z" fill="#2c5773"/>
+<path d="M235 630 L235 315 L335 315 L335 630 Z" fill="#224863"/>
+<path d="M390 630 L390 255 L520 255 L520 630 Z" fill="#18344b"/>
+<path d="M585 630 L585 330 L690 330 L690 630 Z" fill="#2a5f7f"/>
+<path d="M750 630 L750 225 L900 225 L900 630 Z" fill="#17324d"/>
+<path d="M960 630 L960 290 L1085 290 L1085 630 Z" fill="#295270"/>
+<path d="M130 180 L340 110 L530 178 L700 98 L960 180" fill="none" stroke="#f5efe6" stroke-width="8" stroke-linecap="round" opacity="0.75"/>
+<circle cx="130" cy="180" r="13" fill="#f5efe6"/>
+<circle cx="340" cy="110" r="13" fill="#f5efe6"/>
+<circle cx="530" cy="178" r="13" fill="#f5efe6"/>
+<circle cx="700" cy="98" r="13" fill="#f5efe6"/>
+<circle cx="960" cy="180" r="13" fill="#f5efe6"/>
+<text x="90" y="92" fill="#f8f3ea" font-size="46" font-family="Helvetica, Arial, sans-serif" font-weight="700">Seed Event</text>
+<text x="90" y="138" fill="#f8f3ea" font-size="24" font-family="Helvetica, Arial, sans-serif">City meetup placeholder</text>
+</svg>

--- a/app/uploads/seed-events/creative-session.svg
+++ b/app/uploads/seed-events/creative-session.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title id="title">Creative session placeholder</title>
+<desc id="desc">Abstract workshop and creative placeholder for seeded events.</desc>
+<defs>
+<linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+<stop offset="0%" stop-color="#1f2234"/>
+<stop offset="100%" stop-color="#645c89"/>
+</linearGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect x="120" y="120" width="420" height="280" rx="26" fill="#f1ecdf"/>
+<rect x="160" y="168" width="340" height="22" rx="11" fill="#d7cfb9"/>
+<rect x="160" y="218" width="210" height="22" rx="11" fill="#d7cfb9"/>
+<rect x="160" y="268" width="292" height="22" rx="11" fill="#d7cfb9"/>
+<rect x="160" y="318" width="248" height="22" rx="11" fill="#d7cfb9"/>
+<circle cx="854" cy="244" r="126" fill="#f18f6a"/>
+<path d="M784 198 L960 374" stroke="#f7e9d3" stroke-width="26" stroke-linecap="round"/>
+<path d="M960 198 L784 374" stroke="#f7e9d3" stroke-width="26" stroke-linecap="round"/>
+<path d="M722 470 C782 390 882 390 942 470" fill="none" stroke="#f7e9d3" stroke-width="18" stroke-linecap="round"/>
+<circle cx="760" cy="500" r="20" fill="#f7e9d3"/>
+<circle cx="840" cy="470" r="20" fill="#f7e9d3"/>
+<circle cx="920" cy="500" r="20" fill="#f7e9d3"/>
+<text x="92" y="92" fill="#f8f3ea" font-size="46" font-family="Helvetica, Arial, sans-serif" font-weight="700">Seed Event</text>
+<text x="92" y="138" fill="#f8f3ea" font-size="24" font-family="Helvetica, Arial, sans-serif">Workshop placeholder</text>
+</svg>

--- a/app/uploads/seed-events/outdoor-gathering.svg
+++ b/app/uploads/seed-events/outdoor-gathering.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title id="title">Outdoor gathering placeholder</title>
+<desc id="desc">Abstract outdoor placeholder for seeded events.</desc>
+<defs>
+<linearGradient id="sky" x1="0%" y1="0%" x2="0%" y2="100%">
+<stop offset="0%" stop-color="#f6d28f"/>
+<stop offset="55%" stop-color="#f8ead1"/>
+<stop offset="100%" stop-color="#cfe6d8"/>
+</linearGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#sky)"/>
+<circle cx="965" cy="118" r="66" fill="#f19d65"/>
+<path d="M0 390 C160 340 290 330 430 376 C550 416 705 430 850 392 C970 362 1090 330 1200 350 L1200 630 L0 630 Z" fill="#8cb88f"/>
+<path d="M0 475 C150 435 300 425 435 470 C560 510 725 520 870 485 C1015 450 1100 438 1200 452 L1200 630 L0 630 Z" fill="#5f8e69"/>
+<path d="M170 460 C170 362 244 285 340 285 C438 285 514 360 514 460 Z" fill="#fff5e3" opacity="0.95"/>
+<path d="M730 445 C730 365 792 302 872 302 C952 302 1014 365 1014 445 Z" fill="#fff5e3" opacity="0.9"/>
+<circle cx="340" cy="366" r="20" fill="#5f8e69"/>
+<circle cx="872" cy="380" r="18" fill="#5f8e69"/>
+<path d="M258 480 L422 480" stroke="#486d55" stroke-width="14" stroke-linecap="round"/>
+<path d="M794 464 L950 464" stroke="#486d55" stroke-width="14" stroke-linecap="round"/>
+<text x="92" y="96" fill="#3f5b4b" font-size="46" font-family="Helvetica, Arial, sans-serif" font-weight="700">Seed Event</text>
+<text x="92" y="140" fill="#3f5b4b" font-size="24" font-family="Helvetica, Arial, sans-serif">Outdoor placeholder</text>
+</svg>


### PR DESCRIPTION
## What changed
- updated the event seeder so every seeded event gets at least one valid category
- replaced unreachable `example.com` image URLs with committed local placeholder SVGs served from `app/uploads/seed-events`
- allowed those placeholder seed assets through `.gitignore`
- aligned seeded fee objects to use `currency` and reduced seeded `maxAttendees` values to the request-layer cap

## Why it changed
Seeded events were missing category relationships and pointing at dead image URLs, which made the baseline data less realistic and less useful for local development and tests.

## Impact
- developers now get seeded events with valid categories and stable app-served images
- seed data is closer to request-layer expectations for fees and attendee limits
- event/category-related behavior is better represented in the baseline dataset

## Remaining seeder coverage gaps
- `events.seeder.ts` still uses `Event.insertMany(...)`, so event save hooks are skipped and seeded events do not create the author RSVP side effect
- seeded users are still not linked to interests
- seed data still does not fully model all app-side behavior beyond these realism fixes

## Validation
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand tests/requests/events.test.ts tests/services/eventService.test.ts`
