### PR TITLE
Return titled event relations and reset seeded data

### DIFF
--- a/app/src/seeders/categories.seeder.ts
+++ b/app/src/seeders/categories.seeder.ts
@@ -68,20 +68,17 @@ export async function seed() {
 
 async function createCategories(categories: SeedCategory[]) {
     for (const item of categories) {
-        const exists = await Category.findOne({ title: item.title, parent: item.parent });
-        if (!exists) {
-            const savedCategory = await Category.create(item);
-            if (item.subcategories) {
-                item.subcategories.forEach(subcategory => {
-                    subcategory.parent = savedCategory.id
-                })
-                await createCategories(item.subcategories);
-            }
+        const savedCategory = await Category.create(item);
+        if (item.subcategories) {
+            item.subcategories.forEach(subcategory => {
+                subcategory.parent = savedCategory.id
+            })
+            await createCategories(item.subcategories);
+        }
 
-            if (!process.env.JEST_WORKER_ID) {
-                // eslint-disable-next-line
-                console.log(`Created: ${item.title}`);
-            }
+        if (!process.env.JEST_WORKER_ID) {
+            // eslint-disable-next-line
+            console.log(`Created: ${item.title}`);
         }
     }
 }

--- a/app/src/seeders/events.seeder.ts
+++ b/app/src/seeders/events.seeder.ts
@@ -1,6 +1,7 @@
 import { Event } from "@/models/event/Event";
 import { EventType } from "@/models/EventType";
 import { Category } from "@/models/category/Category";
+import { RSVP } from "@/models/rsvp/RSVP";
 import { User } from "@/models/user/User";
 
 const EVENT_HOURS = [18, 19, 20, 9, 16, 17, 12, 15, 14, 21];
@@ -137,6 +138,9 @@ export function buildSeedEventDates(
 }
 
 export async function seed() {
+    await RSVP.deleteMany({});
+    await Event.deleteMany({});
+
     const eventTypes = await EventType.find({}, { _id: 1 }).lean();
 
     if (!eventTypes.length) {

--- a/app/src/seeders/events.seeder.ts
+++ b/app/src/seeders/events.seeder.ts
@@ -48,6 +48,10 @@ function shuffle<T>(values: T[], random: RandomFn): T[] {
     return result;
 }
 
+function getCategorySlice(categories: { _id: unknown }[], start: number, count: number) {
+    return Array.from({ length: count }, (_, offset) => categories[(start + offset) % categories.length]._id);
+}
+
 function pickThisWeekDate(referenceDate: Date): Date {
     const weekDates = getWeekDates(referenceDate);
     const nextDate = weekDates.find(date => !isSameDay(date, referenceDate) && date > referenceDate);
@@ -341,9 +345,16 @@ export async function seed() {
             active: false
         },
     ];
+    const categoryAssignments = events.map((_, index) => [categories[index % categories.length]._id]);
+
+    categoryAssignments[0] = getCategorySlice(categories, 0, 4);
+    categoryAssignments[1] = getCategorySlice(categories, 4, 3);
+    categoryAssignments[2] = getCategorySlice(categories, 7, 2);
+    categoryAssignments[3] = getCategorySlice(categories, 9, 2);
+
     const eventsToInsert = events.map((event, index) => ({
         ...event,
-        categories: [categories[index % categories.length]._id],
+        categories: categoryAssignments[index],
         author: randomUserId(),
         type: randomEventTypeId(),
     }));

--- a/app/src/seeders/events.seeder.ts
+++ b/app/src/seeders/events.seeder.ts
@@ -3,10 +3,15 @@ import { EventType } from "@/models/EventType";
 import { Category } from "@/models/category/Category";
 import { RSVP } from "@/models/rsvp/RSVP";
 import { User } from "@/models/user/User";
+import { Types } from "mongoose";
 
 const EVENT_HOURS = [18, 19, 20, 9, 16, 17, 12, 15, 14, 21];
 
 type RandomFn = () => number;
+
+interface IdOnlyDocument {
+    _id: Types.ObjectId;
+}
 
 function startOfWeek(value: Date): Date {
     const result = new Date(value.getFullYear(), value.getMonth(), value.getDate());
@@ -48,7 +53,7 @@ function shuffle<T>(values: T[], random: RandomFn): T[] {
     return result;
 }
 
-function getCategorySlice(categories: { _id: unknown }[], start: number, count: number) {
+function getCategorySlice(categories: IdOnlyDocument[], start: number, count: number): Types.ObjectId[] {
     return Array.from({ length: count }, (_, offset) => categories[(start + offset) % categories.length]._id);
 }
 
@@ -145,19 +150,19 @@ export async function seed() {
     await RSVP.deleteMany({});
     await Event.deleteMany({});
 
-    const eventTypes = await EventType.find({}, { _id: 1 }).lean();
+    const eventTypes = await EventType.find({}, { _id: 1 }).lean() as IdOnlyDocument[];
 
     if (!eventTypes.length) {
         throw new Error("No event types found");
     }
 
-    const categories = await Category.find({}, { _id: 1 }).sort({ _id: 1 }).lean();
+    const categories = await Category.find({}, { _id: 1 }).sort({ _id: 1 }).lean() as IdOnlyDocument[];
 
     if (!categories.length) {
         throw new Error("No categories found");
     }
 
-    const users = await User.find({}, { _id: 1 }).lean();
+    const users = await User.find({}, { _id: 1 }).lean() as IdOnlyDocument[];
 
     if (!users.length) {
         throw new Error("No users found to assign as authors");
@@ -345,7 +350,9 @@ export async function seed() {
             active: false
         },
     ];
-    const categoryAssignments = events.map((_, index) => [categories[index % categories.length]._id]);
+    const categoryAssignments: Types.ObjectId[][] = events.map(
+        (_, index) => [categories[index % categories.length]._id]
+    );
 
     categoryAssignments[0] = getCategorySlice(categories, 0, 4);
     categoryAssignments[1] = getCategorySlice(categories, 4, 3);

--- a/app/src/seeders/eventtypes.seeder.ts
+++ b/app/src/seeders/eventtypes.seeder.ts
@@ -13,13 +13,10 @@ export async function seed() {
     ];
 
     for (const item of eventTypes) {
-        const exists = await EventType.findOne({ title: item.title });
-        if (!exists) {
-            await EventType.create(item);
-            if (!process.env.JEST_WORKER_ID) {
-                // eslint-disable-next-line
-                console.log(`Created event type: ${item.title}`);
-            }
+        await EventType.create(item);
+        if (!process.env.JEST_WORKER_ID) {
+            // eslint-disable-next-line
+            console.log(`Created event type: ${item.title}`);
         }
     }
     if (!process.env.JEST_WORKER_ID) {

--- a/app/src/seeders/interests.seeder.ts
+++ b/app/src/seeders/interests.seeder.ts
@@ -15,13 +15,10 @@ export async function seed() {
     ];
 
     for (const item of interests) {
-        const exists = await Interest.findOne({ title: item.title });
-        if (!exists) {
-            await Interest.create(item);
-            if (!process.env.JEST_WORKER_ID) {
-                // eslint-disable-next-line
-                console.log(`Created: ${item.title}`);
-            }
+        await Interest.create(item);
+        if (!process.env.JEST_WORKER_ID) {
+            // eslint-disable-next-line
+            console.log(`Created: ${item.title}`);
         }
     }
     if (!process.env.JEST_WORKER_ID) {

--- a/app/src/seeders/runner.ts
+++ b/app/src/seeders/runner.ts
@@ -1,5 +1,47 @@
 import 'dotenv/config';
 import { connectToMongo } from "@/config/mongoConfig";
+import { Category } from "@/models/category/Category";
+import { Event } from "@/models/event/Event";
+import { EventType } from "@/models/EventType";
+import { Interest } from "@/models/Interest";
+import { RSVP } from "@/models/rsvp/RSVP";
+import { User } from "@/models/user/User";
+
+const seeders = ["categories", "interests", "users", "eventtypes", "events"] as const;
+
+const resetters: Record<(typeof seeders)[number], () => Promise<void>> = {
+  categories: async () => {
+    await RSVP.deleteMany({});
+    await Event.deleteMany({});
+    await Category.deleteMany({});
+  },
+  interests: async () => {
+    await Interest.deleteMany({});
+  },
+  users: async () => {
+    await RSVP.deleteMany({});
+    await Event.deleteMany({});
+    await User.deleteMany({});
+  },
+  eventtypes: async () => {
+    await RSVP.deleteMany({});
+    await Event.deleteMany({});
+    await EventType.deleteMany({});
+  },
+  events: async () => {
+    await RSVP.deleteMany({});
+    await Event.deleteMany({});
+  }
+};
+
+async function resetSeedData() {
+  await RSVP.deleteMany({});
+  await Event.deleteMany({});
+  await User.deleteMany({});
+  await Category.deleteMany({});
+  await Interest.deleteMany({});
+  await EventType.deleteMany({});
+}
 
 async function run() {
   await connectToMongo();
@@ -12,7 +54,7 @@ async function run() {
     process.exit(1);
   }
   if (seederName === "all") {
-    const seeders = ["categories", "interests", "users", "eventtypes", "events"];
+    await resetSeedData();
     for (const name of seeders) {
       try {
         await runSeeder(name);
@@ -34,6 +76,9 @@ async function run() {
 
 async function runSeeder(seederName: string) {
   try {
+    if (seederName in resetters) {
+      await resetters[seederName as keyof typeof resetters]();
+    }
     const { seed } = await import(`./${seederName}.seeder`);
     await seed();
   } catch (err) {

--- a/app/src/seeders/users.seeder.ts
+++ b/app/src/seeders/users.seeder.ts
@@ -26,11 +26,9 @@ export async function seed() {
 
     for (const user of users) {
         const newUser = await register(user.username, user.email, user.password);
-        if (newUser) {
-            if (!process.env.JEST_WORKER_ID) {
-                // eslint-disable-next-line
-                console.log(`Created user: ${user.username}`);
-            }
+        if (newUser && !process.env.JEST_WORKER_ID) {
+            // eslint-disable-next-line
+            console.log(`Created user: ${user.username}`);
         }
     }
     if (!process.env.JEST_WORKER_ID) {
@@ -39,14 +37,6 @@ export async function seed() {
     }
 }
 async function register(username: string, email: string, password: string) {
-    const userExistsEmail = await User.findOne({ email });
-    if (userExistsEmail) {
-        return;
-    }
-    const userExistsUsername = await User.findOne({ username });
-    if (userExistsUsername) {
-        return;
-    }
     const user = await User.create({ username, email, password });
 
     if (user) {

--- a/app/src/services/eventService.ts
+++ b/app/src/services/eventService.ts
@@ -41,7 +41,11 @@ export async function list(data: RequestData) {
         buildFilterQuery<IEvent>(data.dbFilter),
         buildSearchQuery<IEvent>(['title', 'description'], data.search)
     );
-    const result = await Event.find(query).sort(buildSortQuery(data.sort)).paginate(data.pagination.offset, data.pagination.limit)
+    const result = await Event.find(query)
+        .populate('categories')
+        .populate('type')
+        .sort(buildSortQuery(data.sort))
+        .paginate(data.pagination.offset, data.pagination.limit)
     return result;
 }
 
@@ -68,7 +72,11 @@ export async function create(data: CreateEventInput, author: string) {
 export async function geoSearch(coordinates: CoordinatesInput, data: RequestData) {
     const query = combineQueries<IEvent>({ active: true }, buildGeosearchQuery(coordinates))
     try {
-        const result = await Event.find(query).sort(buildSortQuery(data.sort)).paginate(data.pagination.offset, data.pagination.limit);
+        const result = await Event.find(query)
+            .populate('categories')
+            .populate('type')
+            .sort(buildSortQuery(data.sort))
+            .paginate(data.pagination.offset, data.pagination.limit);
         return result;
     } catch (error) {
         logger.error("Error performing geosearch on events:", error)

--- a/app/tests/requests/events.test.ts
+++ b/app/tests/requests/events.test.ts
@@ -41,11 +41,20 @@ function startOfWeek(value: Date): Date {
 
 describe("GET /:eventId", () => {
     it("Should return event with author, categories and type data", async () => {
-        const event = await getOneEvent();
-        if (!event) {
+        const author = await getOneUser();
+        const type = await getOneEventType();
+        const category = await getOneCategory();
+        const event = await createFakeEvent({
+            author: author._id.toString(),
+            type: type._id.toString(),
+            categories: [category._id.toString()]
+        }, true);
+        if (!event._id) {
             throw new Error("No events in DB!");
         }
-        const expectedDate = Math.floor(event.date.getTime() / 1000);
+        const expectedDate = typeof event.date === "number"
+            ? event.date
+            : Math.floor(event.date.getTime() / 1000);
         const res = await request(app).get(`/api/event/${event._id.toString()}`).send();
         expect(res.statusCode).toBe(200);
         expect(res.body).toHaveProperty('data');
@@ -58,8 +67,14 @@ describe("GET /:eventId", () => {
         expect(res.body.data.author).toHaveProperty('email');
         expect(res.body.data).toHaveProperty('categories');
         expect(res.body.data).toHaveProperty('type');
-        expect(res.body.data.type).toHaveProperty('_id');
-        expect(res.body.data.type).toHaveProperty('title');
+        expect(res.body.data.type).toMatchObject({
+            _id: type._id.toString(),
+            title: type.title
+        });
+        expect(res.body.data.categories[0]).toMatchObject({
+            _id: category._id.toString(),
+            title: category.title
+        });
         expect(res.body.data).toHaveProperty('description');
         expect(res.body.data).toHaveProperty('date');
         expect(res.body.data.date).toBe(expectedDate);
@@ -201,6 +216,14 @@ describe("GET /api/event filters, search and sorting", () => {
         const res = await request(app).get("/api/event").query({ type_eq: alternateTypeId }).send();
         expect(res.statusCode).toBe(200);
         expect(res.body.data.map((event: { title: string }) => event.title)).toEqual(["Alternate Type Event"]);
+        expect(res.body.data[0].type).toMatchObject({
+            _id: alternateTypeId,
+            title: "Alternate Type"
+        });
+        expect(res.body.data[0].categories[0]).toMatchObject({
+            _id: defaultCategoryId
+        });
+        expect(res.body.data[0].categories[0]).toHaveProperty("title");
     });
 
     it("Should filter events by category", async () => {
@@ -210,6 +233,14 @@ describe("GET /api/event filters, search and sorting", () => {
         const res = await request(app).get("/api/event").query({ categories_in: `[${alternateCategoryId}]` }).send();
         expect(res.statusCode).toBe(200);
         expect(res.body.data.map((event: { title: string }) => event.title)).toEqual(["Alternate Category Event"]);
+        expect(res.body.data[0].type).toMatchObject({
+            _id: defaultTypeId
+        });
+        expect(res.body.data[0].type).toHaveProperty("title");
+        expect(res.body.data[0].categories[0]).toMatchObject({
+            _id: alternateCategoryId,
+            title: "Alternate Category"
+        });
     });
 
     it("Should merge date_after and date_before filters", async () => {
@@ -312,8 +343,12 @@ describe("GET /api/event filters, search and sorting", () => {
     });
 
     it("Should keep geosearch reachable and working as a static route", async () => {
+        const eventType = await getOneEventType();
+        const category = await getOneCategory();
         await createFakeEvent({
             title: "Nearby Event",
+            type: eventType._id.toString(),
+            categories: [category._id.toString()],
             location: {
                 type: "Point",
                 coordinates: [48.21649, 16.40087]
@@ -327,6 +362,15 @@ describe("GET /api/event filters, search and sorting", () => {
 
         expect(res.statusCode).toBe(200);
         expect(res.body.data.map((event: { title: string }) => event.title)).toContain("Nearby Event");
+        const nearbyEvent = res.body.data.find((event: { title: string }) => event.title === "Nearby Event");
+        expect(nearbyEvent.type).toMatchObject({
+            _id: eventType._id.toString(),
+            title: eventType.title
+        });
+        expect(nearbyEvent.categories[0]).toMatchObject({
+            _id: category._id.toString(),
+            title: category.title
+        });
     });
 });
 

--- a/app/tests/services/eventService.test.ts
+++ b/app/tests/services/eventService.test.ts
@@ -101,6 +101,12 @@ describe("list events tests SUCCESS", () => {
         expect(result.length).toBe(1)
         expect(result[0].title).toBe(event.title)
         expect(result[0].author).toEqual(user._id)
+        expect(result[0].type).toMatchObject({
+            _id: eventTypeId
+        })
+        expect(result[0].categories[0]).toMatchObject({
+            _id: categoryId
+        })
     })
     it("Should return empty array when there are no events", async () => {
         const result = await listEvents(requestData)
@@ -188,6 +194,12 @@ describe("geosearch events tests SUCCESS", () => {
         }
         expect(foundEvent.title).toBe(eventTitle)
         expect(foundEvent.author).toEqual(userId)
+        expect(foundEvent.type).toMatchObject({
+            _id: eventTypeId
+        })
+        expect(foundEvent.categories[0]).toMatchObject({
+            _id: categoryId
+        })
     })
 
     it("Should return empty array when there are no events", async () => {


### PR DESCRIPTION
## What changed
- return populated type and categories objects on read-side event APIs instead of raw IDs
- add request and service test coverage for the richer event response shape
- make seeders reset existing seeded data before inserting fresh fixtures
- clear dependent RSVP and event data in dependency-safe order when reseeding related collections

## Why it changed
- event payloads needed human-readable category and event type titles instead of only IDs
- rerunning seeders previously skipped existing rows and left stale data in place

## Impact
- API consumers of GET /api/event, GET /api/event/:eventId, and GET /api/event/geosearch now receive {_id, title} objects for type and categories
- local and dev seeding becomes repeatable: rerunning a seeder replaces old seeded data instead of accumulating or preserving stale fixtures

## Validation
- cd app && npm run lint
- cd app && npm test -- --config jest.config.ts --runInBand tests/requests/events.test.ts
- cd app && npm test -- --config jest.config.ts --runInBand tests/services/eventService.test.ts