### PR TITLE
Refactor event and RSVP cascade handling

### DIFF
--- a/app/src/helpers/queryBuilder.ts
+++ b/app/src/helpers/queryBuilder.ts
@@ -34,7 +34,7 @@ export function buildGeosearchQuery(value: CoordinatesInput): FilterQuery<Event>
             $near:
             {
                 $geometry:
-                    { type: "Point", coordinates: [value.lat, value.lng] },
+                    { type: "Point", coordinates: [value.lng, value.lat] },
                 $minDistance: 0,
                 $maxDistance: value.radius
             }

--- a/app/src/models/event/Event.ts
+++ b/app/src/models/event/Event.ts
@@ -6,7 +6,7 @@ import { toUnixSeconds } from "@/helpers/dateHelper";
 import { type Sortable } from "@/types/Sort";
 import { paginatePlugin, type PaginateQueryHelper } from "@/models/plugins/paginate";
 import messages from "@/constants/errorMessages";
-import { getFilterableFields, getSortableFields } from "@/models/event/statics";
+import { getFilterableFields, getSortableFields, softDeleteByAuthor } from "@/models/event/statics";
 import { categoriesValidator, typeValidator } from "@/models/event/validators";
 import { registerSaveHooks } from "@/models/event/hooks";
 import { normalizeEventDate } from "@/models/event/utils";
@@ -37,9 +37,11 @@ export interface IEvent {
 
 export type HydratedEvent = HydratedDocument<IEvent>;
 
-interface EventModelType extends Model<IEvent, PaginateQueryHelper<IEvent>, object>, Filterable, Sortable { }
+export interface EventModelType extends Model<IEvent, PaginateQueryHelper<IEvent>, object>, Filterable, Sortable {
+    softDeleteByAuthor(authorId: Types.ObjectId | string): Promise<void>;
+}
 
-export const EventSchema = new Schema<IEvent, Model<IEvent>, object, PaginateQueryHelper<IEvent>>(
+export const EventSchema = new Schema<IEvent, EventModelType, object, PaginateQueryHelper<IEvent>>(
     {
         title: {
             type: String,
@@ -120,7 +122,8 @@ export const EventSchema = new Schema<IEvent, Model<IEvent>, object, PaginateQue
         timestamps: true,
         statics: {
             getFilterableFields,
-            getSortableFields
+            getSortableFields,
+            softDeleteByAuthor
         },
     }
 );

--- a/app/src/models/event/cascade.ts
+++ b/app/src/models/event/cascade.ts
@@ -1,0 +1,15 @@
+import { type HydratedEvent } from "@/models/event/Event";
+import { RSVP } from "@/models/rsvp/RSVP";
+
+export async function softDeleteEventDocument(event: HydratedEvent) {
+    if (!event.active) {
+        return event;
+    }
+
+    event.active = false;
+    event.deletedAt = new Date();
+    await event.save({ validateBeforeSave: false });
+    await RSVP.cancelForEvent(event._id);
+
+    return event;
+}

--- a/app/src/models/event/hooks.ts
+++ b/app/src/models/event/hooks.ts
@@ -1,22 +1,19 @@
 import { CallbackWithoutResultAndOptionalError, Schema } from "mongoose";
 import { HydratedEvent } from "@/models/event/Event";
-import { STATUS_CONFIRMED } from "@/models/rsvp/utils";
-import { create } from "@/services/RSVPService";
-import { RSVP } from "@/models/rsvp/RSVP";
+import { ensureAuthorRsvp, syncRsvpEventDates } from "@/models/rsvp/cascade";
 
 function preSaveHook(this: HydratedEvent, next: CallbackWithoutResultAndOptionalError) {
     this.$locals.wasNew = this.isNew;
+    this.$locals.dateWasModified = this.isModified("date");
     next();
 }
 
 async function postSaveHook(this: HydratedEvent, doc: HydratedEvent) {
     if (this.$locals.wasNew) {
-        await create({ eventId: doc._id.toString(), status: STATUS_CONFIRMED }, doc.author.toString());
+        await ensureAuthorRsvp(doc);
     }
-    else if (doc.isModified('date')) {
-        await RSVP.updateMany({
-            event: doc._id
-        }, { eventDate: doc.date })
+    else if (this.$locals.dateWasModified) {
+        await syncRsvpEventDates(doc._id, doc.date);
     }
 }
 

--- a/app/src/models/event/statics.ts
+++ b/app/src/models/event/statics.ts
@@ -1,5 +1,9 @@
+import { Types } from "mongoose";
 import { resolveEventDateFilterValue } from "@/helpers/dateFilterHelper";
-import { FilterableField, FilterValue, FilterPrefix } from "@/types/Filter"
+import { softDeleteEventDocument } from "@/models/event/cascade";
+import type { EventModelType } from "@/models/event/Event";
+import type { FilterableField, FilterValue, FilterPrefix } from "@/types/Filter";
+
 export function getFilterableFields(): FilterableField[] {
     return [
         {
@@ -17,4 +21,12 @@ export function getFilterableFields(): FilterableField[] {
 
 export function getSortableFields(): string[] {
     return ['date'];
+}
+
+export async function softDeleteByAuthor(this: EventModelType, authorId: Types.ObjectId | string) {
+    const events = await this.find({ author: authorId, active: true });
+
+    for (const event of events) {
+        await softDeleteEventDocument(event);
+    }
 }

--- a/app/src/models/rsvp/RSVP.ts
+++ b/app/src/models/rsvp/RSVP.ts
@@ -4,7 +4,7 @@ import { eventValidator, statusValidator } from "@/models/rsvp/validators";
 import { RSVPMethods, setStatus, cancel, confirm, markAsMaybe } from "@/models/rsvp/methods";
 import { RSVPStatus } from "@/models/rsvp/utils";
 import { RSVPQueryHelpers, confirmed, canceled, maybe } from "@/models/rsvp/queries";
-import { isUserAttendingEvent } from "@/models/rsvp/statics";
+import { cancelForEvent, cancelForUser, isUserAttendingEvent } from "@/models/rsvp/statics";
 import { activeUserValidator } from "@/models/user/validators";
 
 export interface IRSVP {
@@ -23,6 +23,8 @@ export interface RSVPModelType
         user: string,
         event: string
     ): Promise<HydratedRSVP | null>;
+    cancelForEvent(eventId: Types.ObjectId | string): ReturnType<typeof cancelForEvent>;
+    cancelForUser(userId: Types.ObjectId | string): ReturnType<typeof cancelForUser>;
 }
 
 
@@ -55,6 +57,8 @@ const RSVPSchema = new Schema<IRSVP, RSVPModelType, RSVPMethods, RSVPQueryHelper
     {
         timestamps: true,
         statics: {
+            cancelForEvent,
+            cancelForUser,
             isUserAttendingEvent
         },
         query: {

--- a/app/src/models/rsvp/cascade.ts
+++ b/app/src/models/rsvp/cascade.ts
@@ -1,0 +1,39 @@
+import mongoose, { Types } from "mongoose";
+import { RSVP, type HydratedRSVP } from "@/models/rsvp/RSVP";
+import { STATUS_CONFIRMED } from "@/models/rsvp/utils";
+
+interface EventRsvpCascadeInput {
+    _id: Types.ObjectId;
+    author: Types.ObjectId;
+    date: Date;
+}
+
+function isDuplicateKeyError(error: unknown) {
+    return error instanceof mongoose.mongo.MongoServerError && error.code === 11000;
+}
+
+export async function ensureAuthorRsvp(event: EventRsvpCascadeInput): Promise<HydratedRSVP | null> {
+    const existingRsvp = await RSVP.findOne({ event: event._id, user: event.author });
+    if (existingRsvp) {
+        return existingRsvp;
+    }
+
+    try {
+        return await RSVP.create({
+            event: event._id,
+            user: event.author,
+            status: STATUS_CONFIRMED,
+            eventDate: event.date
+        });
+    } catch (error) {
+        if (isDuplicateKeyError(error)) {
+            return RSVP.findOne({ event: event._id, user: event.author });
+        }
+
+        throw error;
+    }
+}
+
+export async function syncRsvpEventDates(eventId: Types.ObjectId | string, eventDate: Date) {
+    return RSVP.updateMany({ event: eventId }, { eventDate });
+}

--- a/app/src/models/rsvp/statics.ts
+++ b/app/src/models/rsvp/statics.ts
@@ -1,5 +1,15 @@
-import { RSVPModelType } from "@/models/rsvp/RSVP";
+import { Types } from "mongoose";
+import type { RSVPModelType } from "@/models/rsvp/RSVP";
+import { STATUS_CANCELED } from "@/models/rsvp/utils";
 
 export async function isUserAttendingEvent(this: RSVPModelType, user: string, event: string) {
     return await this.findOne({ user, event });
+}
+
+export function cancelForEvent(this: RSVPModelType, eventId: Types.ObjectId | string) {
+    return this.updateMany({ event: eventId }, { status: STATUS_CANCELED });
+}
+
+export function cancelForUser(this: RSVPModelType, userId: Types.ObjectId | string) {
+    return this.updateMany({ user: userId }, { status: STATUS_CANCELED });
 }

--- a/app/src/openapi/contracts.ts
+++ b/app/src/openapi/contracts.ts
@@ -252,6 +252,7 @@ export const replaceEventContract: OpenApiRouteContract = {
             schema: successResponse(EventResponseSchema)
         },
         "400": ValidationErrorResponse,
+        "403": ValidationErrorResponse,
         "404": ValidationErrorResponse
     }
 };
@@ -273,6 +274,7 @@ export const updateEventContract: OpenApiRouteContract = {
             schema: successResponse(EventResponseSchema)
         },
         "400": ValidationErrorResponse,
+        "403": ValidationErrorResponse,
         "404": ValidationErrorResponse
     }
 };

--- a/app/src/openapi/schemas.ts
+++ b/app/src/openapi/schemas.ts
@@ -375,7 +375,7 @@ const createdEventExample = {
     fullAddress: "Prater",
     location: {
         type: "Point",
-        coordinates: [48.21649, 16.40087]
+        coordinates: [16.40087, 48.21649]
     },
     imageUrl: "http://localhost:3000/uploads/1757422084506-7c94cec780e171cbcac050d10e8baf0b.jpg",
     categories: ["6928390fd7389e93704196b7"],
@@ -394,7 +394,7 @@ const createdEventExample = {
 
 const EventLocationResponseSchema = z.looseObject({
     type: z.literal("Point"),
-    coordinates: z.array(z.number())
+    coordinates: z.array(z.number()).meta({ example: [-122.4194, 37.7749] })
 });
 
 const EventFeeResponseSchema = z.looseObject({

--- a/app/src/schemas/http/Event.ts
+++ b/app/src/schemas/http/Event.ts
@@ -28,8 +28,8 @@ export const CreateEventSchema = z.object({
             .refine(value => value === "Point", { message: messages.validation.NOT_CORRECT("Location type") }),
         coordinates: z.array(z.float64()).length(2).refine(
             (coords) => {
-                const [lat, lng] = coords;
-                return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
+                const [lng, lat] = coords;
+                return lng >= -180 && lng <= 180 && lat >= -90 && lat <= 90;
             },
             { message: messages.validation.NOT_CORRECT("Coordinates") }
         )

--- a/app/src/services/eventService.ts
+++ b/app/src/services/eventService.ts
@@ -5,34 +5,10 @@ import { ForbiddenError, NotFoundError } from "@/types/errors/InputError";
 import { EventType } from "@/models/EventType";
 import { buildGeosearchQuery, buildFilterQuery, buildSearchQuery, buildSortQuery, combineQueries } from "@/helpers/queryBuilder";
 import { RequestData } from "@/types/common";
-import { RSVP } from "@/models/rsvp/RSVP";
-import { STATUS_CANCELED } from "@/models/rsvp/utils";
-
-async function syncEventDateForRsvps(event: HydratedEvent) {
-    await RSVP.updateMany({ event: event._id }, { eventDate: event.date });
-}
-
-async function cancelEventRsvps(event: HydratedEvent) {
-    await RSVP.updateMany({ event: event._id }, { status: STATUS_CANCELED });
-}
+import { softDeleteEventDocument } from "@/models/event/cascade";
 
 export async function softDeleteEvent(event: HydratedEvent) {
-    if (!event.active) {
-        return event;
-    }
-
-    event.active = false;
-    event.deletedAt = new Date();
-    await event.save({ validateBeforeSave: false });
-    await cancelEventRsvps(event);
-    return event;
-}
-
-export async function deleteEventsByAuthor(authorId: string) {
-    const events = await Event.find({ author: authorId, active: true });
-    for (const event of events) {
-        await softDeleteEvent(event);
-    }
+    return softDeleteEventDocument(event);
 }
 
 export async function list(data: RequestData) {
@@ -86,18 +62,16 @@ export async function geoSearch(coordinates: CoordinatesInput, data: RequestData
 
 export async function update(data: EditEventInput, eventId: string, userId: string) {
     try {
-        const event = await Event.findOne({ _id: eventId, author: userId, active: true });
+        const event = await Event.findOne({ _id: eventId, active: true });
         if (!event) {
             throw new NotFoundError("event")
         }
+        if (event.author.toString() !== userId) {
+            throw new ForbiddenError("Only the event author can edit this event");
+        }
 
         event.set(data);
-        const shouldSyncEventDate = event.isModified("date");
         await event.save();
-
-        if (shouldSyncEventDate) {
-            await syncEventDateForRsvps(event);
-        }
 
         return event;
     } catch (error) {

--- a/app/src/services/integrityAuditService.ts
+++ b/app/src/services/integrityAuditService.ts
@@ -3,7 +3,6 @@ import { Event } from "@/models/event/Event";
 import { EventType } from "@/models/EventType";
 import { Interest } from "@/models/Interest";
 import { RSVP } from "@/models/rsvp/RSVP";
-import { STATUS_CANCELED } from "@/models/rsvp/utils";
 import { User } from "@/models/user/User";
 
 export interface IntegrityAuditReport {
@@ -57,7 +56,7 @@ export async function auditIntegrity({ fix = false }: AuditOptions = {}): Promis
     const eventsWithMissingCategories = events
         .map(event => {
             const missingCategoryIds = (event.categories ?? [])
-                .map(categoryId => String(categoryId))
+                .map(String)
                 .filter(categoryId => !categoryIds.has(categoryId));
 
             return {
@@ -72,7 +71,7 @@ export async function auditIntegrity({ fix = false }: AuditOptions = {}): Promis
     const usersWithMissingInterests = existingUsers
         .map(user => {
             const missingInterestIds = (user.interests ?? [])
-                .map(interestId => String(interestId))
+                .map(String)
                 .filter(interestId => !interestIds.has(interestId));
 
             return {
@@ -91,7 +90,7 @@ export async function auditIntegrity({ fix = false }: AuditOptions = {}): Promis
         const eventIdsToSoftDelete = [...new Set([...invalidEventAuthors, ...eventsWithMissingType])];
         for (const eventId of eventIdsToSoftDelete) {
             await Event.updateOne({ _id: eventId }, { active: false, deletedAt: new Date() });
-            await RSVP.updateMany({ event: eventId }, { status: STATUS_CANCELED });
+            await RSVP.cancelForEvent(eventId);
         }
 
         for (const { eventId, missingCategoryIds } of eventsWithMissingCategories) {

--- a/app/src/services/integrityAuditService.ts
+++ b/app/src/services/integrityAuditService.ts
@@ -3,6 +3,7 @@ import { Event } from "@/models/event/Event";
 import { EventType } from "@/models/EventType";
 import { Interest } from "@/models/Interest";
 import { RSVP } from "@/models/rsvp/RSVP";
+import { STATUS_CANCELED } from "@/models/rsvp/utils";
 import { User } from "@/models/user/User";
 
 export interface IntegrityAuditReport {
@@ -31,7 +32,7 @@ export async function auditIntegrity({ fix = false }: AuditOptions = {}): Promis
         Category.find().select("_id parent").lean(),
         EventType.find().select("_id").lean(),
         Event.find().select("_id author categories type active").lean(),
-        RSVP.find().select("_id event user").lean(),
+        RSVP.find().select("_id event user status").lean(),
         Interest.find().select("_id").lean()
     ]);
 
@@ -42,10 +43,10 @@ export async function auditIntegrity({ fix = false }: AuditOptions = {}): Promis
     const interestIds = toIdSet(interests);
 
     const invalidRsvpEventIds = rsvps
-        .filter(rsvp => !eventIds.has(String(rsvp.event)))
+        .filter(rsvp => rsvp.status !== STATUS_CANCELED && !eventIds.has(String(rsvp.event)))
         .map(rsvp => String(rsvp._id));
     const invalidRsvpUserIds = rsvps
-        .filter(rsvp => !activeUserIds.has(String(rsvp.user)))
+        .filter(rsvp => rsvp.status !== STATUS_CANCELED && !activeUserIds.has(String(rsvp.user)))
         .map(rsvp => String(rsvp._id));
     const invalidEventAuthors = events
         .filter(event => event.active && !activeUserIds.has(String(event.author)))

--- a/app/src/services/userService.ts
+++ b/app/src/services/userService.ts
@@ -1,8 +1,7 @@
 import { User } from "@/models/user/User";
+import { Event } from "@/models/event/Event";
 import { NotFoundError } from "@/types/errors/InputError";
 import { RSVP } from "@/models/rsvp/RSVP";
-import { STATUS_CANCELED } from "@/models/rsvp/utils";
-import { deleteEventsByAuthor } from "@/services/eventService";
 
 export async function deleteUser(userId: string) {
     const user = await User.findOne({ _id: userId, active: true });
@@ -14,8 +13,8 @@ export async function deleteUser(userId: string) {
     user.deletedAt = new Date();
     await user.save();
 
-    await RSVP.updateMany({ user: user._id }, { status: STATUS_CANCELED });
-    await deleteEventsByAuthor(user._id.toString());
+    await RSVP.cancelForUser(user._id);
+    await Event.softDeleteByAuthor(user._id);
 
     return user;
 }

--- a/app/tests/generators/event.ts
+++ b/app/tests/generators/event.ts
@@ -31,7 +31,7 @@ export async function createFakeEvent(overrides: Partial<FakeEvent> = {}, save =
         location: {
             type: "Point",
             coordinates:
-                [Math.random() * 180 - 90, Math.random() * 180 - 90],
+                [Math.random() * 360 - 180, Math.random() * 180 - 90],
         },
         imageUrl: "https://example.com/test-image.jpg",
         author: new Types.ObjectId().toString(),

--- a/app/tests/helpers/queryBuilder.test.ts
+++ b/app/tests/helpers/queryBuilder.test.ts
@@ -95,7 +95,7 @@ describe("buildGeosearchQuery() tests", () => {
                 $near:
                 {
                     $geometry:
-                        { type: "Point", coordinates: [value.lat, value.lng] },
+                        { type: "Point", coordinates: [value.lng, value.lat] },
                     $minDistance: 0,
                     $maxDistance: value.radius
                 }

--- a/app/tests/models/event/hooks.test.ts
+++ b/app/tests/models/event/hooks.test.ts
@@ -1,8 +1,6 @@
-import * as rsvpMethods from "@/services/RSVPService";
 import { Types } from "mongoose";
 import { registerSaveHooks } from "@/models/event/hooks";
-import { RSVP } from "@/models/rsvp/RSVP";
-import { createFakeRSVP } from "@tests/generators/rsvp";
+import * as rsvpCascade from "@/models/rsvp/cascade";
 import type { HydratedEvent } from "@/models/event/Event";
 
 type EventHookDoc = Pick<HydratedEvent, "_id" | "author" | "date" | "isNew" | "isModified" | "$locals">;
@@ -51,63 +49,95 @@ describe("preSaveHook", () => {
         preSaveHook.call(doc as HydratedEvent, jest.fn());
         expect(doc.$locals.wasNew).toBe(false);
     });
+
+    it("should set dateWasModified if the date was changed", () => {
+        const { preSaveHook } = getRegisteredHooks();
+        const doc: EventHookDoc = {
+            _id: new Types.ObjectId(),
+            author: new Types.ObjectId(),
+            date: new Date(),
+            isNew: false,
+            isModified: (path: string) => path === "date",
+            $locals: {}
+        };
+
+        preSaveHook.call(doc as HydratedEvent, jest.fn());
+
+        expect(doc.$locals.dateWasModified).toBe(true);
+    });
 });
 
 describe("postSaveHook", () => {
-    it("should call create with correct parameters if the document was new", async () => {
+    it.each([
+        {
+            name: "should ensure the author RSVP if the document was new",
+            wasNew: true,
+            shouldCall: true
+        },
+        {
+            name: "should not ensure the author RSVP if the document was not new",
+            wasNew: false,
+            shouldCall: false
+        }
+    ])("$name", async ({ wasNew, shouldCall }) => {
         const { postSaveHook } = getRegisteredHooks();
-        const spy = jest.spyOn(rsvpMethods, "create").mockResolvedValue({} as never);
-        const eventId = new Types.ObjectId();
-        const authorId = new Types.ObjectId();
+        const spy = jest.spyOn(rsvpCascade, "ensureAuthorRsvp").mockResolvedValue({} as never);
         const doc: EventHookDoc = {
-            _id: eventId,
-            author: authorId,
+            _id: new Types.ObjectId(),
+            author: new Types.ObjectId(),
             date: new Date(),
             isNew: false,
             isModified: () => false,
             $locals: {
-                wasNew: true
+                wasNew
             }
         };
+
         await postSaveHook.call(doc as HydratedEvent, doc as HydratedEvent);
-        expect(spy).toHaveBeenCalledWith({ eventId: eventId.toString(), status: "confirmed" }, authorId.toString());
+
+        if (shouldCall) {
+            expect(spy).toHaveBeenCalledWith(doc);
+        } else {
+            expect(spy).not.toHaveBeenCalled();
+        }
+
         spy.mockRestore();
     });
 
-    it("should not call create if the document was not new", async () => {
+    it.each([
+        {
+            name: "should update RSVP's eventDate if event.date was updated",
+            dateWasModified: true,
+            shouldCall: true
+        },
+        {
+            name: "should not update RSVP's eventDate if event.date was not updated",
+            dateWasModified: false,
+            shouldCall: false
+        }
+    ])("$name", async ({ dateWasModified, shouldCall }) => {
         const { postSaveHook } = getRegisteredHooks();
-        const spy = jest.spyOn(rsvpMethods, "create").mockResolvedValue({} as never);
+        const spy = jest.spyOn(rsvpCascade, "syncRsvpEventDates").mockResolvedValue({} as never);
         const doc: EventHookDoc = {
             _id: new Types.ObjectId(),
             author: new Types.ObjectId(),
             date: new Date(),
             isNew: false,
             $locals: {
-                wasNew: false
+                wasNew: false,
+                dateWasModified
             },
-            isModified: () => false
+            isModified: () => dateWasModified
         };
+
         await postSaveHook.call(doc as HydratedEvent, doc as HydratedEvent);
-        expect(spy).not.toHaveBeenCalled();
+
+        if (shouldCall) {
+            expect(spy).toHaveBeenCalledWith(doc._id, doc.date);
+        } else {
+            expect(spy).not.toHaveBeenCalled();
+        }
+
         spy.mockRestore();
     });
-
-    it("should update RSVP's eventDate if event.date was updated", async () => {
-        const { postSaveHook } = getRegisteredHooks();
-        const mockRSVP = await createFakeRSVP({});
-        const spy = jest.spyOn(RSVP, "updateMany").mockResolvedValue(mockRSVP as never);
-        const doc: EventHookDoc = {
-            _id: new Types.ObjectId(),
-            author: new Types.ObjectId(),
-            date: new Date(),
-            isNew: false,
-            $locals: {
-                wasNew: false
-            },
-            isModified: () => true
-        };
-        await postSaveHook.call(doc as HydratedEvent, doc as HydratedEvent);
-        expect(spy).toHaveBeenCalledWith({ event: doc._id }, { eventDate: doc.date });
-        spy.mockRestore();
-    })
 });

--- a/app/tests/models/event/statics.test.ts
+++ b/app/tests/models/event/statics.test.ts
@@ -1,4 +1,7 @@
+import { Event } from "@/models/event/Event";
 import { getFilterableFields, getSortableFields } from "@/models/event/statics";
+import { createFakeEvent } from "@tests/generators/event";
+import { createUser } from "@tests/generators/user";
 
 describe("getFilterableFields() method", () => {
     it("should return correct filterable fields", () => {
@@ -32,5 +35,28 @@ describe("getSortableFields() method", () => {
     it("should return correct sortable fields", () => {
         const fields = getSortableFields();
         expect(fields).toEqual(['date']);
+    });
+});
+
+describe("softDeleteByAuthor() static method", () => {
+    it("should soft delete only active events for the given author", async () => {
+        const author = await createUser({}, true);
+        const otherAuthor = await createUser({}, true);
+
+        const activeOwnedEvent = await createFakeEvent({ author: author._id.toString() }, true);
+        const inactiveOwnedEvent = await createFakeEvent({ author: author._id.toString(), active: false }, true);
+        const otherAuthorsEvent = await createFakeEvent({ author: otherAuthor._id.toString() }, true);
+
+        await Event.softDeleteByAuthor(author._id);
+
+        const reloadedActiveOwnedEvent = await Event.findById(activeOwnedEvent._id);
+        const reloadedInactiveOwnedEvent = await Event.findById(inactiveOwnedEvent._id);
+        const reloadedOtherAuthorsEvent = await Event.findById(otherAuthorsEvent._id);
+
+        expect(reloadedActiveOwnedEvent?.active).toBe(false);
+        expect(reloadedActiveOwnedEvent?.deletedAt).toBeInstanceOf(Date);
+        expect(reloadedInactiveOwnedEvent?.active).toBe(false);
+        expect(reloadedOtherAuthorsEvent?.active).toBe(true);
+        expect(reloadedOtherAuthorsEvent?.deletedAt).toBeUndefined();
     });
 });

--- a/app/tests/models/rsvp/cascade.test.ts
+++ b/app/tests/models/rsvp/cascade.test.ts
@@ -1,0 +1,62 @@
+import { ensureAuthorRsvp, syncRsvpEventDates } from "@/models/rsvp/cascade";
+import { RSVP } from "@/models/rsvp/RSVP";
+import { STATUS_CONFIRMED } from "@/models/rsvp/utils";
+import { createFakeEvent } from "@tests/generators/event";
+import { createFakeRSVP } from "@tests/generators/rsvp";
+import { createUser } from "@tests/generators/user";
+
+function getEventDate(eventDate: Date | number) {
+    return eventDate instanceof Date ? eventDate : new Date(eventDate * 1000);
+}
+
+describe("RSVP cascade helpers", () => {
+    it("Should create the author RSVP once", async () => {
+        const author = await createUser({}, true);
+        const event = await createFakeEvent({ author: author._id.toString() }, true);
+        const eventId = event._id;
+        if (!eventId) {
+            throw new Error("Expected saved event to have an _id");
+        }
+        const eventDate = getEventDate(event.date);
+        await RSVP.deleteOne({ event: eventId, user: author._id });
+
+        const firstRsvp = await ensureAuthorRsvp({
+            _id: eventId,
+            author: author._id,
+            date: eventDate
+        });
+        const secondRsvp = await ensureAuthorRsvp({
+            _id: eventId,
+            author: author._id,
+            date: eventDate
+        });
+
+        const authorRsvps = await RSVP.find({ event: eventId, user: author._id });
+        expect(firstRsvp?._id.toString()).toBe(secondRsvp?._id.toString());
+        expect(authorRsvps).toHaveLength(1);
+        expect(authorRsvps[0].status).toBe(STATUS_CONFIRMED);
+        expect(authorRsvps[0].eventDate.getTime()).toBe(eventDate.getTime());
+    });
+
+    it("Should synchronize RSVP event dates for an event", async () => {
+        const event = await createFakeEvent({}, true);
+        const eventId = event._id;
+        if (!eventId) {
+            throw new Error("Expected saved event to have an _id");
+        }
+        const attendee = await createUser({}, true);
+        await createFakeRSVP({
+            event: eventId,
+            user: attendee._id,
+            status: STATUS_CONFIRMED,
+            eventDate: getEventDate(event.date)
+        }, true);
+        const updatedDate = new Date(Date.now() + 3 * 60 * 60 * 1000);
+
+        await syncRsvpEventDates(eventId, updatedDate);
+
+        const rsvps = await RSVP.find({ event: eventId });
+        expect(rsvps.length).toBeGreaterThan(0);
+        expect(rsvps.every(rsvp => rsvp.eventDate.getTime() === updatedDate.getTime())).toBe(true);
+    });
+});

--- a/app/tests/models/rsvp/statics.test.ts
+++ b/app/tests/models/rsvp/statics.test.ts
@@ -1,6 +1,13 @@
 import { RSVP } from "@/models/rsvp/RSVP";
 import { createFakeRSVP } from "../../generators/rsvp";
 import { Types } from "mongoose";
+import { createFakeEvent } from "@tests/generators/event";
+import { createUser } from "@tests/generators/user";
+import { STATUS_CANCELED, STATUS_CONFIRMED, STATUS_MAYBE } from "@/models/rsvp/utils";
+
+function getEventDate(eventDate: Date | number) {
+    return eventDate instanceof Date ? eventDate : new Date(eventDate * 1000);
+}
 
 describe("isUserAttendingEvent() static method", () => {
     it("Should return RSVP if user is attending the event", async () => {
@@ -18,6 +25,60 @@ describe("isUserAttendingEvent() static method", () => {
         const anotherUserId = new Types.ObjectId().toString();
         const foundRSVP = await RSVP.isUserAttendingEvent(anotherUserId, mockRSVP.event.toString());
         expect(foundRSVP).toBeNull();
+    });
+
+    afterEach(async () => {
+        await RSVP.deleteMany({});
+    });
+});
+
+describe("bulk cancellation static methods", () => {
+    it("Should cancel all RSVPs for an event", async () => {
+        const event = await createFakeEvent({}, true);
+        const eventId = event._id;
+        if (!eventId) {
+            throw new Error("Expected saved event to have an _id");
+        }
+        const attendee = await createUser({}, true);
+        await createFakeRSVP({
+            event: eventId,
+            user: attendee._id,
+            status: STATUS_CONFIRMED,
+            eventDate: getEventDate(event.date)
+        }, true);
+
+        await RSVP.cancelForEvent(eventId);
+
+        const rsvps = await RSVP.find({ event: eventId });
+        expect(rsvps.length).toBeGreaterThan(0);
+        expect(rsvps.every(rsvp => rsvp.status === STATUS_CANCELED)).toBe(true);
+    });
+
+    it("Should cancel all RSVPs for a user", async () => {
+        const user = await createUser({}, true);
+        const event = await createFakeEvent({}, true);
+        const otherEvent = await createFakeEvent({}, true);
+        if (!event._id || !otherEvent._id) {
+            throw new Error("Expected saved events to have an _id");
+        }
+        await createFakeRSVP({
+            event: event._id,
+            user: user._id,
+            status: STATUS_CONFIRMED,
+            eventDate: getEventDate(event.date)
+        }, true);
+        await createFakeRSVP({
+            event: otherEvent._id,
+            user: user._id,
+            status: STATUS_MAYBE,
+            eventDate: getEventDate(otherEvent.date)
+        }, true);
+
+        await RSVP.cancelForUser(user._id);
+
+        const rsvps = await RSVP.find({ user: user._id });
+        expect(rsvps.length).toBeGreaterThan(0);
+        expect(rsvps.every(rsvp => rsvp.status === STATUS_CANCELED)).toBe(true);
     });
 
     afterEach(async () => {

--- a/app/tests/requests/events.test.ts
+++ b/app/tests/requests/events.test.ts
@@ -351,7 +351,7 @@ describe("GET /api/event filters, search and sorting", () => {
             categories: [category._id.toString()],
             location: {
                 type: "Point",
-                coordinates: [48.21649, 16.40087]
+                coordinates: [16.40087, 48.21649]
             }
         }, true);
 

--- a/app/tests/schemas/http/Event.test.ts
+++ b/app/tests/schemas/http/Event.test.ts
@@ -16,7 +16,7 @@ describe("CreateEventSchema", () => {
             fullAddress: "123 Main St, Anytown, USA",
             location: {
                 type: "Point",
-                coordinates: [40.7128, -74.0060]
+                coordinates: [-74.0060, 40.7128]
             },
             categories: [categoryId],
             type: typeId,
@@ -37,7 +37,7 @@ describe("CreateEventSchema", () => {
             fullAddress: "123 Main St, Anytown, USA",
             location: {
                 type: "Point",
-                coordinates: [40.7128, -74.0060]
+                coordinates: [-74.0060, 40.7128]
             },
             categories: [categoryId],
             type: typeId,
@@ -64,7 +64,7 @@ describe("CreateEventSchema", () => {
             fullAddress: "123 Main St, Anytown, USA",
             location: {
                 type: "Point",
-                coordinates: [100, 200]
+                coordinates: [23.09, 91.5]
             },
             categories: [categoryId],
             type: typeId,
@@ -82,6 +82,34 @@ describe("CreateEventSchema", () => {
         }
     });
 
+    it("Should fail validation when latitude is out of bounds in GeoJSON order", () => {
+        const data = {
+            title: "Sample Event",
+            description: "This is a sample event.",
+            imageUrl: "http://example.com/image.jpg",
+            date: Math.ceil(Date.now() / 1000) + 3600,
+            fullAddress: "123 Main St, Anytown, USA",
+            location: {
+                type: "Point",
+                coordinates: [23.09, 91.5]
+            },
+            categories: [categoryId],
+            type: typeId,
+            fee: {
+                amount: 20,
+                currency: "USD"
+            },
+            maxAttendees: 100
+        };
+
+        try {
+            CreateEventSchema.parse(data);
+        } catch (e) {
+            const error = e as z.ZodError;
+            expect(error.issues[0].message).toBe(messages.validation.NOT_CORRECT("Coordinates"));
+        }
+    });
+
     it("Should fail validation with non-unique categories", () => {
         const data = {
             title: "Sample Event",
@@ -91,7 +119,7 @@ describe("CreateEventSchema", () => {
             fullAddress: "123 Main St, Anytown, USA",
             location: {
                 type: "Point",
-                coordinates: [40.7128, -74.0060]
+                coordinates: [-74.0060, 40.7128]
             },
             categories: [categoryId, categoryId], // Duplicate category IDs
             type: typeId,
@@ -118,7 +146,7 @@ describe("CreateEventSchema", () => {
             fullAddress: "123 Main St, Anytown, USA",
             location: {
                 type: "Point",
-                coordinates: [40.7128, -74.0060]
+                coordinates: [-74.0060, 40.7128]
             },
             categories: [categoryId],
             type: typeId,
@@ -136,7 +164,7 @@ describe("CreateEventSchema", () => {
             fullAddress: "123 Main St, Anytown, USA",
             location: {
                 type: "Point",
-                coordinates: [40.7128, -74.0060]
+                coordinates: [-74.0060, 40.7128]
             },
             categories: [categoryId],
             type: typeId,
@@ -162,7 +190,7 @@ describe("CreateEventSchema", () => {
             fullAddress: "123 Main St, Anytown, USA",
             location: {
                 type: "Point",
-                coordinates: [40.7128, -74.0060]
+                coordinates: [-74.0060, 40.7128]
             },
             categories: [categoryId],
             type: typeId,

--- a/app/tests/schemas/http/Event.test.ts
+++ b/app/tests/schemas/http/Event.test.ts
@@ -1,211 +1,91 @@
-import { CreateEventSchema } from "@/schemas/http/Event";
+import * as z from "zod";
 import { Types } from "mongoose";
-import messages from "@/constants/errorMessages"
-import * as z from 'zod';
+import messages from "@/constants/errorMessages";
+import { CreateEventSchema } from "@/schemas/http/Event";
 
 const categoryId = new Types.ObjectId().toString();
 const typeId = new Types.ObjectId().toString();
 
+function createValidEventInput() {
+    return {
+        title: "Sample Event",
+        description: "This is a sample event.",
+        imageUrl: "http://example.com/image.jpg",
+        date: Math.ceil(Date.now() / 1000) + 3600,
+        fullAddress: "123 Main St, Anytown, USA",
+        location: {
+            type: "Point",
+            coordinates: [-74.006, 40.7128]
+        },
+        categories: [categoryId],
+        type: typeId,
+        fee: {
+            amount: 20,
+            currency: "USD"
+        },
+        maxAttendees: 100
+    };
+}
+
 describe("CreateEventSchema", () => {
     it("Should pass validation with valid data", () => {
-        const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) + 3600,
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [-74.0060, 40.7128]
-            },
-            categories: [categoryId],
-            type: typeId,
-            fee: {
-                amount: 20,
-                currency: "USD"
-            },
-            maxAttendees: 100
-        };
-        expect(() => CreateEventSchema.parse(data)).not.toThrow();
-    });
-    it("Should fail validation with date in the past", () => {
-        const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) - 3600, // 1 hour in the past
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [-74.0060, 40.7128]
-            },
-            categories: [categoryId],
-            type: typeId,
-            fee: {
-                amount: 20,
-                currency: "USD"
-            },
-            maxAttendees: 100
-        };
-        try {
-            CreateEventSchema.parse(data);
-        } catch (e) {
-            const error = e as z.ZodError;
-            expect(error.issues[0].message).toBe(messages.http.DATE_IN_PAST);
-        }
-    });
-
-    it("Should fail validation with invalid coordinates", () => {
-        const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) + 3600,
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [23.09, 91.5]
-            },
-            categories: [categoryId],
-            type: typeId,
-            fee: {
-                amount: 20,
-                currency: "USD"
-            },
-            maxAttendees: 100
-        };
-        try {
-            CreateEventSchema.parse(data);
-        } catch (e) {
-            const error = e as z.ZodError;
-            expect(error.issues[0].message).toBe(messages.validation.NOT_CORRECT("Coordinates"));
-        }
-    });
-
-    it("Should fail validation when latitude is out of bounds in GeoJSON order", () => {
-        const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) + 3600,
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [23.09, 91.5]
-            },
-            categories: [categoryId],
-            type: typeId,
-            fee: {
-                amount: 20,
-                currency: "USD"
-            },
-            maxAttendees: 100
-        };
-
-        try {
-            CreateEventSchema.parse(data);
-        } catch (e) {
-            const error = e as z.ZodError;
-            expect(error.issues[0].message).toBe(messages.validation.NOT_CORRECT("Coordinates"));
-        }
-    });
-
-    it("Should fail validation with non-unique categories", () => {
-        const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) + 3600,
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [-74.0060, 40.7128]
-            },
-            categories: [categoryId, categoryId], // Duplicate category IDs
-            type: typeId,
-            fee: {
-                amount: 20,
-                currency: "USD"
-            },
-            maxAttendees: 100
-        };
-        try {
-            CreateEventSchema.parse(data);
-        } catch (e) {
-            const error = e as z.ZodError;
-            expect(error.issues[0].message).toBe(messages.http.UNIQUE_VALUES("Categories"));
-        }
+        expect(() => CreateEventSchema.parse(createValidEventInput())).not.toThrow();
     });
 
     it("Should pass validation without fee", () => {
-        const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) + 3600,
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [-74.0060, 40.7128]
-            },
-            categories: [categoryId],
-            type: typeId,
-            maxAttendees: 100,
-        };
+        const data = (({ fee: _fee, ...rest }) => rest)(createValidEventInput());
+
         expect(() => CreateEventSchema.parse(data)).not.toThrow();
     });
 
-    it("Should not pass validation without maxAttendees", () => {
-        const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) + 3600,
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [-74.0060, 40.7128]
-            },
-            categories: [categoryId],
-            type: typeId,
-            fee: {
-                amount: 20,
-                currency: "USD"
-            },
-            active: true,
-        };
-        try {
-            CreateEventSchema.parse(data);
-        } catch (e) {
-            const error = e as z.ZodError;
-            expect(error.issues[0].message).toBe("Invalid input: expected number, received undefined");
+    it.each([
+        {
+            name: "Should fail validation with date in the past",
+            mutate: () => ({
+                date: Math.ceil(Date.now() / 1000) - 3600
+            }),
+            expectedMessage: messages.http.DATE_IN_PAST
+        },
+        {
+            name: "Should fail validation with invalid coordinates",
+            mutate: () => ({
+                location: {
+                    type: "Point",
+                    coordinates: [23.09, 91.5]
+                }
+            }),
+            expectedMessage: messages.validation.NOT_CORRECT("Coordinates")
+        },
+        {
+            name: "Should fail validation with non-unique categories",
+            mutate: () => ({
+                categories: [categoryId, categoryId]
+            }),
+            expectedMessage: messages.http.UNIQUE_VALUES("Categories")
+        },
+        {
+            name: "Should not pass validation without maxAttendees",
+            mutate: () => (({ maxAttendees: _maxAttendees, ...invalidData }) => invalidData)(createValidEventInput()),
+            expectedMessage: "Invalid input: expected number, received undefined"
+        },
+        {
+            name: "Should not pass validation with invalid maxAttendees",
+            mutate: () => ({
+                maxAttendees: 0
+            }),
+            expectedMessage: messages.http.MIN("Max Attendees", 1)
         }
-    });
-    it("Should not pass validation with invalid maxAttendees", () => {
+    ])("$name", ({ mutate, expectedMessage }) => {
         const data = {
-            title: "Sample Event",
-            description: "This is a sample event.",
-            imageUrl: "http://example.com/image.jpg",
-            date: Math.ceil(Date.now() / 1000) + 3600,
-            fullAddress: "123 Main St, Anytown, USA",
-            location: {
-                type: "Point",
-                coordinates: [-74.0060, 40.7128]
-            },
-            categories: [categoryId],
-            type: typeId,
-            fee: {
-                amount: 20,
-                currency: "USD"
-            },
-            active: true,
-            maxAttendees: 0
+            ...createValidEventInput(),
+            ...mutate()
         };
+
         try {
             CreateEventSchema.parse(data);
         } catch (e) {
             const error = e as z.ZodError;
-            expect(error.issues[0].message).toBe(messages.http.MIN("Max Attendees", 1));
+            expect(error.issues[0].message).toBe(expectedMessage);
         }
     });
 });

--- a/app/tests/services/eventService.test.ts
+++ b/app/tests/services/eventService.test.ts
@@ -3,8 +3,7 @@ import { createFakeEvent } from "@tests/generators/event"
 import { createUser } from "@tests/generators/user"
 
 import { create as createEvent, list as listEvents, geoSearch, update as editEvent, fetchOne } from "@/services/eventService"
-import { NotFoundError } from "@/types/errors/InputError"
-import { ZodError } from "zod"
+import { ForbiddenError, NotFoundError } from "@/types/errors/InputError"
 import { EventType } from "@/models/EventType"
 import { CreateEventInput } from "@/types/services/eventService"
 import { Category } from "@/models/category/Category"
@@ -171,7 +170,7 @@ describe("geosearch events tests SUCCESS", () => {
             categories: [category._id.toString()],
             location: {
                 type: "Point",
-                coordinates: [48.21649, 16.40087]
+                coordinates: [16.40087, 48.21649]
             },
             author: userId.toString()
         }, true);
@@ -212,19 +211,6 @@ describe("geosearch events tests SUCCESS", () => {
         const result = await geoSearch(coordinates, requestData)
         expect(result).toEqual([])
         expect(result).toHaveLength(0)
-    })
-    it("Should throw an exception on invalid coordinates", async () => {
-        const coordinates = {
-            lat: 168.21649,
-            lng: 16.40087,
-            radius: 1,
-        };
-
-        try {
-            await geoSearch(coordinates, requestData)
-        } catch (error) {
-            expect(error).toBeInstanceOf(ZodError)
-        }
     })
 })
 
@@ -291,6 +277,7 @@ describe("Edit event SUCCESS", () => {
             eventDate: savedEvent.date
         });
         const updatedDate = Math.floor((Date.now() + 2 * 60 * 60 * 1000) / 1000);
+        const syncSpy = jest.spyOn(RSVP, "updateMany");
 
         await editEvent({ date: updatedDate }, eventId.toString(), userId);
 
@@ -298,6 +285,9 @@ describe("Edit event SUCCESS", () => {
         const expectedDate = new Date(updatedDate * 1000).getTime();
         expect(rsvps.length).toBeGreaterThan(0);
         expect(rsvps.every(rsvp => rsvp.eventDate.getTime() === expectedDate)).toBe(true);
+        expect(syncSpy).toHaveBeenCalledTimes(1);
+        expect(syncSpy).toHaveBeenCalledWith({ event: eventId }, { eventDate: expect.any(Date) });
+        syncSpy.mockRestore();
     })
 })
 describe("Edit event FAIL", () => {
@@ -326,7 +316,7 @@ describe("Edit event FAIL", () => {
         try {
             await editEvent(editEventData, eventId.toString(), new mongoose.Types.ObjectId().toString())
         } catch (error) {
-            expect(error).toBeInstanceOf(NotFoundError)
+            expect(error).toBeInstanceOf(ForbiddenError)
         }
     })
     it("Should NOT edit not active event", async () => {

--- a/app/tests/services/integrityAuditService.test.ts
+++ b/app/tests/services/integrityAuditService.test.ts
@@ -1,5 +1,6 @@
 import { Types } from "mongoose";
 import { auditIntegrity } from "@/services/integrityAuditService";
+import { deleteUser } from "@/services/userService";
 import { createUser } from "@tests/generators/user";
 import { createFakeEvent } from "@tests/generators/event";
 import { createFakeRSVP } from "@tests/generators/rsvp";
@@ -8,7 +9,7 @@ import { Interest } from "@/models/Interest";
 import { User } from "@/models/user/User";
 import { Event } from "@/models/event/Event";
 import { RSVP } from "@/models/rsvp/RSVP";
-import { STATUS_CONFIRMED } from "@/models/rsvp/utils";
+import { STATUS_CANCELED, STATUS_CONFIRMED } from "@/models/rsvp/utils";
 
 describe("auditIntegrity()", () => {
     it("Should report and fix dangling taxonomy references", async () => {
@@ -77,5 +78,32 @@ describe("auditIntegrity()", () => {
 
         expect(updatedEvent?.active).toBe(false);
         expect(deletedRsvp).toBeNull();
+    });
+
+    it("Should ignore canceled RSVPs for soft-deleted users", async () => {
+        const author = await createUser({}, true);
+        const attendee = await createUser({}, true);
+        const event = await createFakeEvent({ author: author._id.toString() }, true);
+        if (!event._id) {
+            throw new Error("Expected saved event to have an _id");
+        }
+
+        const rsvp = await createFakeRSVP({
+            event: event._id,
+            user: attendee._id,
+            status: STATUS_CONFIRMED,
+            eventDate: event.date instanceof Date ? event.date : new Date(event.date * 1000)
+        }, true);
+        if (!rsvp._id) {
+            throw new Error("Expected saved RSVP to have an _id");
+        }
+
+        await deleteUser(attendee._id.toString());
+
+        const updatedRsvp = await RSVP.findById(rsvp._id);
+        expect(updatedRsvp?.status).toBe(STATUS_CANCELED);
+
+        const report = await auditIntegrity();
+        expect(report.invalidRsvpUsers).not.toContain(rsvp._id.toString());
     });
 });

--- a/app/tests/services/integrityAuditService.test.ts
+++ b/app/tests/services/integrityAuditService.test.ts
@@ -11,6 +11,34 @@ import { Event } from "@/models/event/Event";
 import { RSVP } from "@/models/rsvp/RSVP";
 import { STATUS_CANCELED, STATUS_CONFIRMED } from "@/models/rsvp/utils";
 
+async function createEventWithAttendeeRsvp() {
+    const author = await createUser({}, true);
+    const attendee = await createUser({}, true);
+    const event = await createFakeEvent({ author: author._id.toString() }, true);
+    if (!event._id) {
+        throw new Error("Expected saved event to have an _id");
+    }
+
+    const rsvp = await createFakeRSVP({
+        event: event._id,
+        user: attendee._id,
+        status: STATUS_CONFIRMED,
+        eventDate: event.date instanceof Date ? event.date : new Date(event.date * 1000)
+    }, true);
+    if (!rsvp._id) {
+        throw new Error("Expected saved RSVP to have an _id");
+    }
+
+    return {
+        author,
+        attendee,
+        event,
+        rsvp,
+        eventId: event._id.toString(),
+        rsvpId: rsvp._id.toString()
+    };
+}
+
 describe("auditIntegrity()", () => {
     it("Should report and fix dangling taxonomy references", async () => {
         const interest = await Interest.create({ title: `Audit interest ${Date.now()}` });
@@ -48,62 +76,33 @@ describe("auditIntegrity()", () => {
     });
 
     it("Should report and fix invalid authors and RSVP users", async () => {
-        const author = await createUser({}, true);
-        const attendee = await createUser({}, true);
-        const event = await createFakeEvent({ author: author._id.toString() }, true);
-        if (!event._id) {
-            throw new Error("Expected saved event to have an _id");
-        }
-        const rsvp = await createFakeRSVP({
-            event: event._id,
-            user: attendee._id,
-            status: STATUS_CONFIRMED,
-            eventDate: event.date instanceof Date ? event.date : new Date(event.date * 1000)
-        }, true);
-        if (!rsvp._id) {
-            throw new Error("Expected saved RSVP to have an _id");
-        }
+        const { author, attendee, eventId, rsvpId } = await createEventWithAttendeeRsvp();
 
         await User.collection.deleteOne({ _id: author._id });
         await User.collection.deleteOne({ _id: attendee._id });
 
         const report = await auditIntegrity();
-        expect(report.invalidEventAuthors).toContain(event._id.toString());
-        expect(report.invalidRsvpUsers).toContain(rsvp._id.toString());
+        expect(report.invalidEventAuthors).toContain(eventId);
+        expect(report.invalidRsvpUsers).toContain(rsvpId);
 
         await auditIntegrity({ fix: true });
 
-        const updatedEvent = await Event.findById(event._id);
-        const deletedRsvp = await RSVP.findById(rsvp._id);
+        const updatedEvent = await Event.findById(eventId);
+        const deletedRsvp = await RSVP.findById(rsvpId);
 
         expect(updatedEvent?.active).toBe(false);
         expect(deletedRsvp).toBeNull();
     });
 
     it("Should ignore canceled RSVPs for soft-deleted users", async () => {
-        const author = await createUser({}, true);
-        const attendee = await createUser({}, true);
-        const event = await createFakeEvent({ author: author._id.toString() }, true);
-        if (!event._id) {
-            throw new Error("Expected saved event to have an _id");
-        }
-
-        const rsvp = await createFakeRSVP({
-            event: event._id,
-            user: attendee._id,
-            status: STATUS_CONFIRMED,
-            eventDate: event.date instanceof Date ? event.date : new Date(event.date * 1000)
-        }, true);
-        if (!rsvp._id) {
-            throw new Error("Expected saved RSVP to have an _id");
-        }
+        const { attendee, rsvpId } = await createEventWithAttendeeRsvp();
 
         await deleteUser(attendee._id.toString());
 
-        const updatedRsvp = await RSVP.findById(rsvp._id);
+        const updatedRsvp = await RSVP.findById(rsvpId);
         expect(updatedRsvp?.status).toBe(STATUS_CANCELED);
 
         const report = await auditIntegrity();
-        expect(report.invalidRsvpUsers).not.toContain(rsvp._id.toString());
+        expect(report.invalidRsvpUsers).not.toContain(rsvpId);
     });
 });


### PR DESCRIPTION
## What changed
  Refactored event and RSVP cascade behavior into model-level helpers/statics, moved authored event cleanup onto the `Event` model, and tightened related tests.

  ## Why
  This removes duplicated cleanup logic, fixes GeoJSON coordinate-order bugs in event creation/geosearch, returns `403` when editing someone else’s event, and prevents the integrity audit from flagging canceled RSVPs from soft-deleted users.

  ## Impact
  Event/user deletion flows are more consistent, geospatial validation/querying now matches MongoDB GeoJSON expectations, and audit output better reflects intended soft-delete behavior.