### PR TITLE
[codex] Add current user events endpoint

### DIFF
--- a/app/src/openapi/contracts.ts
+++ b/app/src/openapi/contracts.ts
@@ -186,6 +186,24 @@ export const listEventsContract: OpenApiRouteContract = {
     }
 };
 
+export const listCurrentUserEventsContract: OpenApiRouteContract = {
+    method: "get",
+    path: "/api/event/me",
+    operationId: "listCurrentUserEvents",
+    summary: "List events authored by the current user",
+    tags: ["Events"],
+    authenticated: true,
+    request: { query: EventCollectionQuerySchema },
+    responses: {
+        "200": {
+            description: "Current user event list",
+            schema: successResponse(z.array(EventListItemResponseSchema))
+        },
+        "400": ValidationErrorResponse,
+        "401": ValidationErrorResponse
+    }
+};
+
 export const listEventTypesViaEventContract: OpenApiRouteContract = {
     method: "get",
     path: "/api/event/types",
@@ -463,6 +481,7 @@ export const openApiContracts = [
     uploadMediaContract,
     createEventContract,
     listEventsContract,
+    listCurrentUserEventsContract,
     listEventTypesViaEventContract,
     geoSearchEventsContract,
     fetchEventContract,

--- a/app/src/requests/event/listCurrentUser.ts
+++ b/app/src/requests/event/listCurrentUser.ts
@@ -1,0 +1,10 @@
+import { listCurrentUser as listCurrentUserEvents } from "@/services/eventService";
+import { Request, Response } from "express";
+import { setSuccessResponse } from "@/helpers/requestHelper";
+import { asyncHandler } from "@/requests/asyncHandler";
+import { buildRequestData, getRequestUserId } from "@/requests/utils";
+
+export const listCurrentUser = asyncHandler(async (req: Request, res: Response) => {
+    const events = await listCurrentUserEvents(buildRequestData(req), getRequestUserId(req));
+    setSuccessResponse(res, events.map(event => event.toJSON()));
+});

--- a/app/src/routes/event.ts
+++ b/app/src/routes/event.ts
@@ -18,10 +18,12 @@ import { attend } from "@/requests/event/attend";
 import { listRsvps } from "@/requests/event/listRsvps";
 import { fetchOne } from "@/requests/event/fetchOne";
 import { remove } from "@/requests/event/delete";
+import { listCurrentUser } from "@/requests/event/listCurrentUser";
 export const router = Router()
 
 router.post('/', [authMiddleware, requestSchemaValidate(CreateEventSchema)], create)
 router.get('/', [searchNormalizer, paginateMiddleware, sortMiddleware(Event), filterMiddleware(Event)], list)
+router.get('/me', [authMiddleware, searchNormalizer, paginateMiddleware, sortMiddleware(Event), filterMiddleware(Event)], listCurrentUser)
 router.get('/types', [paginateMiddleware, filterMiddleware(EventType)], getEventTypes)
 router.get('/geosearch', [paginateMiddleware, sortMiddleware(Event)], geosearch)
 router.get('/:eventId', fetchOne)

--- a/app/src/services/eventService.ts
+++ b/app/src/services/eventService.ts
@@ -6,22 +6,32 @@ import { EventType } from "@/models/EventType";
 import { buildGeosearchQuery, buildFilterQuery, buildSearchQuery, buildSortQuery, combineQueries } from "@/helpers/queryBuilder";
 import { RequestData } from "@/types/common";
 import { softDeleteEventDocument } from "@/models/event/cascade";
+import type { FilterQuery } from "mongoose";
 
 export async function softDeleteEvent(event: HydratedEvent) {
     return softDeleteEventDocument(event);
 }
 
-export async function list(data: RequestData) {
+function listByQuery(data: RequestData, baseQuery: FilterQuery<IEvent>) {
     const query = combineQueries<IEvent>(
-        { active: true },
+        baseQuery,
         buildFilterQuery<IEvent>(data.dbFilter),
         buildSearchQuery<IEvent>(['title', 'description'], data.search)
     );
-    const result = await Event.find(query)
+    return Event.find(query)
         .populate('categories')
         .populate('type')
         .sort(buildSortQuery(data.sort))
         .paginate(data.pagination.offset, data.pagination.limit)
+}
+
+export async function list(data: RequestData) {
+    const result = await listByQuery(data, { active: true });
+    return result;
+}
+
+export async function listCurrentUser(data: RequestData, userId: string) {
+    const result = await listByQuery(data, { active: true, author: userId });
     return result;
 }
 

--- a/app/tests/openapi/generate.test.ts
+++ b/app/tests/openapi/generate.test.ts
@@ -14,6 +14,7 @@ describe("generateOpenApiSpec", () => {
         expect(spec.openapi).toBe("3.1.0");
         expect(spec.paths).toHaveProperty("/status");
         expect(spec.paths).toHaveProperty("/api/auth/login");
+        expect(spec.paths).toHaveProperty("/api/event/me");
         expect(spec.paths).toHaveProperty("/api/event/{eventId}");
         expect(spec.paths).toHaveProperty("/api/event/{eventId}/rsvps");
         expect(spec.paths).toHaveProperty("/api/user/password");
@@ -60,6 +61,22 @@ describe("generateOpenApiSpec", () => {
         expect(interestsParameters.map(parameter => parameter.name)).toEqual(expect.arrayContaining([
             "title_eq",
             "title_contains"
+        ]));
+    });
+
+    it("documents current user events as an authenticated event list", () => {
+        const spec = generateOpenApiSpec();
+        const currentUserEventsOperation = asRecord(asRecord(spec.paths["/api/event/me"]).get);
+        const parameters = currentUserEventsOperation.parameters as { name: string }[];
+
+        expect(currentUserEventsOperation.security).toEqual([{ bearerAuth: [] }]);
+        expect(parameters.map(parameter => parameter.name)).toEqual(expect.arrayContaining([
+            "date_eq",
+            "categories_in",
+            "type_eq",
+            "sortByAsc",
+            "sortByDesc",
+            "search"
         ]));
     });
 });

--- a/app/tests/requests/event/me.test.ts
+++ b/app/tests/requests/event/me.test.ts
@@ -38,46 +38,42 @@ describe("GET /api/event/me", () => {
         const category = await getOneCategory();
         const matchingType = await getOneEventType();
         const otherType = await EventType.create({ title: "Current User Events Other Type" });
+        const currentUserId = currentUser._id.toString();
+        const matchingTypeId = matchingType._id.toString();
+        const categoryIds = [category._id.toString()];
+        const createMatchedEvent = (overrides: Parameters<typeof createFakeEvent>[0]) => createFakeEvent({
+            description: "planning meetup",
+            author: currentUserId,
+            categories: categoryIds,
+            type: matchingTypeId,
+            ...overrides
+        }, true);
 
-        await createFakeEvent({
+        await createMatchedEvent({
             title: "Later Matched Event",
-            description: "planning meetup",
-            author: currentUser._id.toString(),
-            categories: [category._id.toString()],
-            type: matchingType._id.toString(),
             date: Math.floor(new Date("2026-03-30T12:00:00.000Z").getTime() / 1000)
-        }, true);
-        await createFakeEvent({
+        });
+        await createMatchedEvent({
             title: "Earlier Matched Event",
-            description: "planning meetup",
-            author: currentUser._id.toString(),
-            categories: [category._id.toString()],
-            type: matchingType._id.toString(),
             date: Math.floor(new Date("2026-03-29T12:00:00.000Z").getTime() / 1000)
-        }, true);
-        await createFakeEvent({
+        });
+        await createMatchedEvent({
             title: "Wrong Type Event",
-            description: "planning meetup",
-            author: currentUser._id.toString(),
-            categories: [category._id.toString()],
             type: otherType._id.toString(),
             date: Math.floor(new Date("2026-03-28T12:00:00.000Z").getTime() / 1000)
-        }, true);
-        await createFakeEvent({
+        });
+        await createMatchedEvent({
             title: "Search Miss Event",
             description: "different words",
-            author: currentUser._id.toString(),
-            categories: [category._id.toString()],
-            type: matchingType._id.toString(),
             date: Math.floor(new Date("2026-03-27T12:00:00.000Z").getTime() / 1000)
-        }, true);
+        });
 
         const res = await request(app)
             .get("/api/event/me")
             .set("Authorization", `Bearer ${token}`)
             .query({
                 search: "planning",
-                type_eq: matchingType._id.toString(),
+                type_eq: matchingTypeId,
                 sortByAsc: "date"
             })
             .send();

--- a/app/tests/requests/event/me.test.ts
+++ b/app/tests/requests/event/me.test.ts
@@ -1,0 +1,102 @@
+import request from "supertest";
+import app from "@/app";
+import { Event } from "@/models/event/Event";
+import { EventType } from "@/models/EventType";
+import { generateToken } from "@/helpers/jwtHelper";
+import { createUser } from "@tests/generators/user";
+import { createFakeEvent } from "@tests/generators/event";
+import { getOneCategory, getOneEventType } from "@tests/getters";
+
+describe("GET /api/event/me", () => {
+    beforeEach(async () => {
+        await Event.deleteMany({});
+    });
+
+    it("Should return only active events authored by the current user", async () => {
+        const currentUser = await createUser({}, true);
+        const otherUser = await createUser({}, true);
+        const token = generateToken(currentUser._id.toString());
+
+        await createFakeEvent({ title: "Current User Event", author: currentUser._id.toString() }, true);
+        await createFakeEvent({ title: "Inactive Current User Event", author: currentUser._id.toString(), active: false }, true);
+        await createFakeEvent({ title: "Other User Event", author: otherUser._id.toString() }, true);
+
+        const res = await request(app)
+            .get("/api/event/me")
+            .set("Authorization", `Bearer ${token}`)
+            .send();
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.map((event: { title: string }) => event.title)).toEqual(["Current User Event"]);
+        expect(res.body.data[0].author).toBe(currentUser._id.toString());
+    });
+
+    it("Should reuse supported event list filters, search, and sorting", async () => {
+        const currentUser = await createUser({}, true);
+        const token = generateToken(currentUser._id.toString());
+        const category = await getOneCategory();
+        const matchingType = await getOneEventType();
+        const otherType = await EventType.create({ title: "Current User Events Other Type" });
+
+        await createFakeEvent({
+            title: "Later Matched Event",
+            description: "planning meetup",
+            author: currentUser._id.toString(),
+            categories: [category._id.toString()],
+            type: matchingType._id.toString(),
+            date: Math.floor(new Date("2026-03-30T12:00:00.000Z").getTime() / 1000)
+        }, true);
+        await createFakeEvent({
+            title: "Earlier Matched Event",
+            description: "planning meetup",
+            author: currentUser._id.toString(),
+            categories: [category._id.toString()],
+            type: matchingType._id.toString(),
+            date: Math.floor(new Date("2026-03-29T12:00:00.000Z").getTime() / 1000)
+        }, true);
+        await createFakeEvent({
+            title: "Wrong Type Event",
+            description: "planning meetup",
+            author: currentUser._id.toString(),
+            categories: [category._id.toString()],
+            type: otherType._id.toString(),
+            date: Math.floor(new Date("2026-03-28T12:00:00.000Z").getTime() / 1000)
+        }, true);
+        await createFakeEvent({
+            title: "Search Miss Event",
+            description: "different words",
+            author: currentUser._id.toString(),
+            categories: [category._id.toString()],
+            type: matchingType._id.toString(),
+            date: Math.floor(new Date("2026-03-27T12:00:00.000Z").getTime() / 1000)
+        }, true);
+
+        const res = await request(app)
+            .get("/api/event/me")
+            .set("Authorization", `Bearer ${token}`)
+            .query({
+                search: "planning",
+                type_eq: matchingType._id.toString(),
+                sortByAsc: "date"
+            })
+            .send();
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data.map((event: { title: string }) => event.title)).toEqual([
+            "Earlier Matched Event",
+            "Later Matched Event"
+        ]);
+        expect(res.body.data[0].type).toMatchObject({
+            _id: matchingType._id.toString(),
+            title: matchingType.title
+        });
+    });
+
+    it("Should reject unauthenticated requests", async () => {
+        const res = await request(app).get("/api/event/me").send();
+
+        expect(res.statusCode).toBe(401);
+        expect(res.body).toEqual({ success: false, message: "Unauthorized" });
+    });
+});


### PR DESCRIPTION
## What changed

- Added authenticated `GET /api/event/me` for events authored by the current user.
- Reused existing event list pagination, sorting, search, and supported filters while deriving ownership from the bearer token.
- Added OpenAPI coverage for the new route.
- Added request tests for owned events, other/inactive event exclusion, unauthenticated rejection, and list behavior reuse.

## Why

Issue 96 asks for a safer "my events" API that does not expose or trust an `author` query parameter on the public event list endpoint.

## Validation

- `npm test -- --config jest.config.ts --runInBand tests/requests/event/me.test.ts tests/openapi/generate.test.ts`
- `npm run lint`
- `npm run build`