### PR TITLE
[codex] Add request logging middleware

### DIFF
--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -12,6 +12,7 @@ import { router } from "@/routes/main";
 import cors from "cors";
 import path from "node:path";
 import { errorHandler } from "@/middlewares/errorHandler";
+import { requestLogging } from "@/middlewares/requestLogging";
 
 /**
  * Create the Express application.
@@ -28,6 +29,7 @@ import { errorHandler } from "@/middlewares/errorHandler";
 const app = express();
 
 app.use(cors());
+app.use(requestLogging);
 app.use(express.json());
 
 /**

--- a/app/src/middlewares/requestLogging.ts
+++ b/app/src/middlewares/requestLogging.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from "node:crypto";
+import { NextFunction, Request, Response } from "express";
+import { logger } from "@/config/loggerConfig";
+
+export const REQUEST_ID_HEADER = "x-request-id";
+
+function getRequestPath(originalUrl: string): string {
+    const [path] = originalUrl.split("?");
+    return path || originalUrl;
+}
+
+export function requestLogging(req: Request, res: Response, next: NextFunction): void {
+    const requestId = req.get(REQUEST_ID_HEADER) || randomUUID();
+    const startedAt = process.hrtime.bigint();
+
+    req.requestId = requestId;
+    res.setHeader(REQUEST_ID_HEADER, requestId);
+
+    res.once("finish", () => {
+        const latency = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+
+        logger.info("request.completed", {
+            requestId,
+            method: req.method,
+            path: getRequestPath(req.originalUrl),
+            status: res.statusCode,
+            latency,
+        });
+    });
+
+    next();
+}

--- a/app/src/types/express/index.d.ts
+++ b/app/src/types/express/index.d.ts
@@ -5,6 +5,7 @@ import { type HydratedUserDoc } from "@/models/user/User";
 declare global {
     namespace Express {
         export interface Request {
+            requestId?: string;
             user?: HydratedUserDoc,
             offset?: number;
             limit?: number;

--- a/app/tests/middlewares/requestLogging.test.ts
+++ b/app/tests/middlewares/requestLogging.test.ts
@@ -1,0 +1,74 @@
+jest.mock("@/config/loggerConfig", () => ({
+    logger: {
+        info: jest.fn(),
+    },
+}));
+
+import { EventEmitter } from "node:events";
+import { NextFunction, Request, Response } from "express";
+import { logger } from "@/config/loggerConfig";
+import { REQUEST_ID_HEADER, requestLogging } from "@/middlewares/requestLogging";
+
+describe("requestLogging middleware", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should propagate request id and log one structured entry after the response finishes", async () => {
+        const requestId = "request-123";
+        const req = {
+            method: "GET",
+            originalUrl: "/logged-route?token=secret",
+            get: jest.fn().mockReturnValue(requestId),
+        } as unknown as Request;
+        const res = Object.assign(new EventEmitter(), {
+            statusCode: 201,
+            setHeader: jest.fn(),
+        }) as unknown as Response;
+        const next = jest.fn(() => {
+            expect(req.requestId).toBe(requestId);
+            res.emit("finish");
+        }) as NextFunction;
+
+        requestLogging(req, res, next);
+
+        expect(res.setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, requestId);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(logger.info).toHaveBeenCalledTimes(1);
+        expect(logger.info).toHaveBeenCalledWith("request.completed", expect.objectContaining({
+            requestId,
+            method: "GET",
+            path: "/logged-route",
+            status: 201,
+            latency: expect.any(Number),
+        }));
+    });
+
+    it("should generate a request id when the header is missing", async () => {
+        const req = {
+            method: "GET",
+            originalUrl: "/generated-request-id",
+            get: jest.fn().mockReturnValue(undefined),
+        } as unknown as Request;
+        const res = Object.assign(new EventEmitter(), {
+            statusCode: 200,
+            setHeader: jest.fn(),
+        }) as unknown as Response;
+        const next = jest.fn(() => {
+            expect(req.requestId).toEqual(expect.any(String));
+            res.emit("finish");
+        }) as NextFunction;
+
+        requestLogging(req, res, next);
+
+        expect(res.setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, expect.any(String));
+        expect(logger.info).toHaveBeenCalledTimes(1);
+        expect(logger.info).toHaveBeenCalledWith("request.completed", expect.objectContaining({
+            requestId: req.requestId,
+            method: "GET",
+            path: "/generated-request-id",
+            status: 200,
+            latency: expect.any(Number),
+        }));
+    });
+});

--- a/app/tests/requests/requestLogging.test.ts
+++ b/app/tests/requests/requestLogging.test.ts
@@ -1,0 +1,37 @@
+import request from "supertest";
+import app from "@/app";
+import { logger } from "@/config/loggerConfig";
+import { REQUEST_ID_HEADER } from "@/middlewares/requestLogging";
+
+jest.mock("@/config/loggerConfig", () => ({
+    logger: {
+        info: jest.fn(),
+        error: jest.fn()
+    }
+}));
+
+describe("request logging", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("logs one structured entry after a request finishes", async () => {
+        const res = await request(app)
+            .get("/status?token=secret")
+            .set(REQUEST_ID_HEADER, "status-request-1");
+        const requestLogCalls = jest.mocked(logger.info).mock.calls.filter(([message]) => (
+            (message as unknown) === "request.completed"
+        ));
+
+        expect(res.statusCode).toBe(200);
+        expect(res.headers[REQUEST_ID_HEADER]).toBe("status-request-1");
+        expect(requestLogCalls).toHaveLength(1);
+        expect(logger.info).toHaveBeenCalledWith("request.completed", {
+            requestId: "status-request-1",
+            method: "GET",
+            path: "/status",
+            status: 200,
+            latency: expect.any(Number)
+        });
+    });
+});

--- a/app/tests/status.test.ts
+++ b/app/tests/status.test.ts
@@ -1,5 +1,6 @@
 import request from "supertest"
 import app from "@/app"
+import { REQUEST_ID_HEADER } from "@/middlewares/requestLogging";
 
 describe("Status test", () => {
 
@@ -7,5 +8,14 @@ describe("Status test", () => {
         const res = await request(app).get('/status')
         expect(res.statusCode).toBe(200)
         expect(res.body.message).toBe('Junto API is running!');
+        expect(res.headers[REQUEST_ID_HEADER]).toEqual(expect.any(String));
+    })
+
+    it("GET /status propagates request id header", async () => {
+        const requestId = "status-request-id";
+        const res = await request(app).get("/status").set(REQUEST_ID_HEADER, requestId);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.headers[REQUEST_ID_HEADER]).toBe(requestId);
     })
 })


### PR DESCRIPTION
## What changed

- Added request logging middleware that propagates or generates an `x-request-id`.
- Exposes the request id to downstream handlers as `req.requestId`.
- Logs one structured `request.completed` entry after each response finishes with request id, method, path, status, and latency.
- Added middleware, request, and status tests for request id propagation and logging behavior.

## Why

Issue #119 asks for structured API request metadata to improve observability and debugging without logging sensitive request bodies or credentials.

## Impact

API responses now include `x-request-id`, and downstream handlers can use `req.requestId` for correlation. Logged paths omit query strings to avoid leaking token-like query parameters.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --config jest.config.ts --runInBand tests/middlewares/requestLogging.test.ts tests/requests/requestLogging.test.ts tests/status.test.ts`

Closes #119