### PR TITLE
[codex] Implement event comments

### DIFF
--- a/app/src/constants/successMessages.ts
+++ b/app/src/constants/successMessages.ts
@@ -1,5 +1,6 @@
 export default {
     response: {
+        COMMENT_DELETED: "Comment has been deleted",
         EVENT_DELETED: "Event has been deleted",
         PASSWORD_UPDATED: "Password has been updated",
         PROFILE_DELETED: "Profile has been deleted"

--- a/app/src/models/comment/Comment.ts
+++ b/app/src/models/comment/Comment.ts
@@ -1,0 +1,74 @@
+import mongoose, { HydratedDocument, Model, Schema, SchemaTypes, Types } from "mongoose";
+import { paginatePlugin, type PaginateQueryHelper } from "@/models/plugins/paginate";
+import { activeEventValidator, activeUserValidator } from "@/models/comment/validators";
+import messages from "@/constants/errorMessages";
+import { deleteForAuthor, deleteForEvent } from "@/models/comment/statics";
+
+export interface IComment {
+    _id: Types.ObjectId;
+    event: Types.ObjectId;
+    author: Types.ObjectId;
+    content: string;
+}
+
+export type HydratedComment = HydratedDocument<IComment>;
+
+export interface CommentModelType extends Model<IComment, PaginateQueryHelper<IComment>> {
+    deleteForEvent(eventId: Types.ObjectId | string): Promise<unknown>;
+    deleteForAuthor(authorId: Types.ObjectId | string): Promise<unknown>;
+}
+
+export const CommentSchema = new Schema<IComment, CommentModelType, object, PaginateQueryHelper<IComment>>(
+    {
+        event: {
+            type: SchemaTypes.ObjectId,
+            required: true,
+            ref: "Event"
+        },
+        author: {
+            type: SchemaTypes.ObjectId,
+            required: true,
+            ref: "User"
+        },
+        content: {
+            type: String,
+            required: true,
+            trim: true,
+            maxlength: [500, messages.http.MAX_LENGTH("Comment", 500)]
+        }
+    },
+    {
+        timestamps: true,
+        statics: {
+            deleteForEvent,
+            deleteForAuthor
+        }
+    }
+);
+
+CommentSchema.path("event").validate({
+    validator: activeEventValidator,
+    message: messages.validation.NOT_EXISTS("event")
+});
+
+CommentSchema.path("author").validate({
+    validator: activeUserValidator,
+    message: messages.validation.NOT_EXISTS("user")
+});
+
+CommentSchema.set("toJSON", {
+    getters: true,
+    virtuals: false,
+    versionKey: false,
+    transform: (_, ret) => {
+        if ("updatedAt" in ret) {
+            delete ret.updatedAt;
+        }
+
+        return ret;
+    }
+});
+
+CommentSchema.plugin(paginatePlugin<IComment>);
+
+export const Comment = mongoose.model<IComment, CommentModelType>("Comment", CommentSchema);

--- a/app/src/models/comment/statics.ts
+++ b/app/src/models/comment/statics.ts
@@ -1,0 +1,10 @@
+import { Types } from "mongoose";
+import type { CommentModelType } from "@/models/comment/Comment";
+
+export async function deleteForEvent(this: CommentModelType, eventId: Types.ObjectId | string) {
+    return this.deleteMany({ event: eventId });
+}
+
+export async function deleteForAuthor(this: CommentModelType, authorId: Types.ObjectId | string) {
+    return this.deleteMany({ author: authorId });
+}

--- a/app/src/models/comment/validators.ts
+++ b/app/src/models/comment/validators.ts
@@ -1,0 +1,13 @@
+import { Types } from "mongoose";
+import { Event } from "@/models/event/Event";
+import { User } from "@/models/user/User";
+
+export async function activeEventValidator(value: Types.ObjectId) {
+    const eventExists = await Event.exists({ _id: value, active: true });
+    return !!eventExists;
+}
+
+export async function activeUserValidator(value: Types.ObjectId) {
+    const userExists = await User.exists({ _id: value, active: true });
+    return !!userExists;
+}

--- a/app/src/models/event/cascade.ts
+++ b/app/src/models/event/cascade.ts
@@ -1,5 +1,6 @@
 import { type HydratedEvent } from "@/models/event/Event";
 import { RSVP } from "@/models/rsvp/RSVP";
+import { Comment } from "@/models/comment/Comment";
 
 export async function softDeleteEventDocument(event: HydratedEvent) {
     if (!event.active) {
@@ -10,6 +11,7 @@ export async function softDeleteEventDocument(event: HydratedEvent) {
     event.deletedAt = new Date();
     await event.save({ validateBeforeSave: false });
     await RSVP.cancelForEvent(event._id);
+    await Comment.deleteForEvent(event._id);
 
     return event;
 }

--- a/app/src/openapi/contracts.ts
+++ b/app/src/openapi/contracts.ts
@@ -1,6 +1,7 @@
 import * as z from "zod";
 import { RegisterSchema, LoginSchema } from "../schemas/http/Auth";
 import { CoordinatesSchema, CreateEventSchema, EditEventSchema } from "../schemas/http/Event";
+import { CreateEventCommentSchema } from "../schemas/http/Comment";
 import { UpdateProfileSchema, UpdatePasswordSchema } from "../schemas/http/Profile";
 import { CreateRSVPSchema, UpdateRSVPSchema } from "../schemas/http/RSVP";
 import { SearchQuerySchema } from "../schemas/http/Search";
@@ -9,6 +10,8 @@ import type { OpenApiRouteContract } from "./types";
 import {
     CategoriesResponseSchema,
     CreatedEventResponseSchema,
+    CommentListResponseSchema,
+    CommentResponseSchema,
     DeleteEventResponseSchema,
     ErrorResponseSchema,
     EventDetailResponseSchema,
@@ -254,6 +257,26 @@ export const fetchEventContract: OpenApiRouteContract = {
     }
 };
 
+export const listEventCommentsContract: OpenApiRouteContract = {
+    method: "get",
+    path: "/api/comments/:eventId",
+    operationId: "listEventComments",
+    summary: "List comments for an event",
+    tags: ["Events", "Comments"],
+    request: {
+        params: EventIdParamsSchema,
+        query: PaginationQuerySchema
+    },
+    responses: {
+        "200": {
+            description: "Comment list",
+            schema: successResponse(CommentListResponseSchema)
+        },
+        "400": ValidationErrorResponse,
+        "404": ValidationErrorResponse
+    }
+};
+
 export const replaceEventContract: OpenApiRouteContract = {
     method: "put",
     path: "/api/event/:eventId",
@@ -364,6 +387,25 @@ export const getCurrentUserEventRsvpContract: OpenApiRouteContract = {
         "200": {
             description: "Current user's RSVP",
             schema: successResponse(CurrentUserRsvpResponseSchema)
+        },
+        "400": ValidationErrorResponse,
+        "401": ValidationErrorResponse,
+        "404": ValidationErrorResponse
+    }
+};
+
+export const createEventCommentContract: OpenApiRouteContract = {
+    method: "post",
+    path: "/api/comments",
+    operationId: "createEventComment",
+    summary: "Create a comment on an event",
+    tags: ["Events", "Comments"],
+    authenticated: true,
+    request: { body: CreateEventCommentSchema },
+    responses: {
+        "201": {
+            description: "Created comment",
+            schema: successResponse(CommentResponseSchema)
         },
         "400": ValidationErrorResponse,
         "401": ValidationErrorResponse,
@@ -503,12 +545,14 @@ export const openApiContracts = [
     listEventTypesViaEventContract,
     geoSearchEventsContract,
     fetchEventContract,
+    listEventCommentsContract,
     replaceEventContract,
     updateEventContract,
     deleteEventContract,
     attendEventContract,
     listEventRsvpsContract,
     getCurrentUserEventRsvpContract,
+    createEventCommentContract,
     listInterestsContract,
     listCategoriesContract,
     updateRsvpContract,

--- a/app/src/openapi/contracts.ts
+++ b/app/src/openapi/contracts.ts
@@ -12,6 +12,7 @@ import {
     CreatedEventResponseSchema,
     CommentListResponseSchema,
     CommentResponseSchema,
+    DeleteCommentResponseSchema,
     DeleteEventResponseSchema,
     ErrorResponseSchema,
     EventDetailResponseSchema,
@@ -47,6 +48,10 @@ const ServerErrorResponse = {
 
 const EventIdParamsSchema = z.object({
     eventId: ObjectIdParamSchema
+});
+
+const CommentIdParamsSchema = z.object({
+    commentId: ObjectIdParamSchema
 });
 
 const RSVPIdParamsSchema = z.object({
@@ -413,6 +418,25 @@ export const createEventCommentContract: OpenApiRouteContract = {
     }
 };
 
+export const deleteCommentContract: OpenApiRouteContract = {
+    method: "delete",
+    path: "/api/comments/:commentId",
+    operationId: "deleteComment",
+    summary: "Delete a comment",
+    tags: ["Comments"],
+    authenticated: true,
+    request: { params: CommentIdParamsSchema },
+    responses: {
+        "200": {
+            description: "Comment deletion confirmation",
+            schema: successResponse(DeleteCommentResponseSchema)
+        },
+        "400": ValidationErrorResponse,
+        "403": ValidationErrorResponse,
+        "404": ValidationErrorResponse
+    }
+};
+
 export const listInterestsContract: OpenApiRouteContract = {
     method: "get",
     path: "/api/interests",
@@ -553,6 +577,7 @@ export const openApiContracts = [
     listEventRsvpsContract,
     getCurrentUserEventRsvpContract,
     createEventCommentContract,
+    deleteCommentContract,
     listInterestsContract,
     listCategoriesContract,
     updateRsvpContract,

--- a/app/src/openapi/schemas.ts
+++ b/app/src/openapi/schemas.ts
@@ -460,6 +460,44 @@ export const EventDetailResponseSchema = EventListItemResponseSchema.omit({
     }
 });
 
+const commentAuthorExample = {
+    _id: "69e22b13ba1baa17b151ae43",
+    username: "ArtSoul",
+    avatarUrl: "http://localhost:3000/uploads/avatar.jpg"
+};
+
+const commentExample = {
+    _id: "69e496748a67eb4e7fc5dd9c",
+    event: "69e22b13ba1baa17b151ae62",
+    author: commentAuthorExample,
+    content: "Looking forward to this event.",
+    createdAt: "2026-04-19T09:00:00.000Z"
+};
+
+const commentListExample = {
+    total: 1,
+    entities: [commentExample]
+};
+
+export const CommentAuthorResponseSchema = z.looseObject({
+    _id: IdSchema,
+    username: z.string(),
+    avatarUrl: z.string().optional()
+});
+
+export const CommentResponseSchema = z.looseObject({
+    _id: IdSchema,
+    event: IdSchema,
+    author: CommentAuthorResponseSchema,
+    content: z.string(),
+    createdAt: z.string()
+}).meta({ example: commentExample });
+
+export const CommentListResponseSchema = z.object({
+    total: z.number(),
+    entities: z.array(CommentResponseSchema)
+}).meta({ example: commentListExample });
+
 export const CreatedEventResponseSchema = EventResponseSchema.extend({
     date: z.union([z.number(), z.string()]).meta({ example: createdEventExample.date }),
     fee: EventFeeResponseSchema,

--- a/app/src/openapi/schemas.ts
+++ b/app/src/openapi/schemas.ts
@@ -58,6 +58,12 @@ export const DeleteEventResponseSchema = MessageSchema.meta({
     }
 });
 
+export const DeleteCommentResponseSchema = MessageSchema.meta({
+    example: {
+        message: "Comment has been deleted"
+    }
+});
+
 export const PasswordUpdatedResponseSchema = MessageSchema.meta({
     example: {
         message: "Password has been updated"

--- a/app/src/requests/comment/createComment.ts
+++ b/app/src/requests/comment/createComment.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from "express";
+import { asyncHandler } from "@/requests/asyncHandler";
+import { setSuccessResponse } from "@/helpers/requestHelper";
+import { CreateEventCommentSchema } from "@/schemas/http/Comment";
+import { create as createCommentService } from "@/services/commentService";
+import { getRequestUserId } from "@/requests/utils";
+
+export const createComment = asyncHandler(async (req: Request, res: Response) => {
+    const data = CreateEventCommentSchema.parse(req.body);
+    const comment = await createCommentService(data, getRequestUserId(req));
+
+    setSuccessResponse(res, comment.toJSON(), 201);
+});

--- a/app/src/requests/comment/deleteComment.ts
+++ b/app/src/requests/comment/deleteComment.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from "express";
+import successMessages from "@/constants/successMessages";
+import { setSuccessResponse } from "@/helpers/requestHelper";
+import { asyncHandler } from "@/requests/asyncHandler";
+import { getRequestUserId } from "@/requests/utils";
+import { deleteComment as deleteCommentService } from "@/services/commentService";
+import { BadInputError } from "@/types/errors/InputError";
+
+export const deleteComment = asyncHandler(async (req: Request, res: Response) => {
+    if (!req.params.commentId) {
+        throw new BadInputError("commentId", "Comment ID is required");
+    }
+
+    await deleteCommentService(req.params.commentId, getRequestUserId(req));
+    setSuccessResponse(res, { message: successMessages.response.COMMENT_DELETED });
+});

--- a/app/src/requests/comment/listComments.ts
+++ b/app/src/requests/comment/listComments.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from "express";
+import { asyncHandler } from "@/requests/asyncHandler";
+import { setSuccessResponse } from "@/helpers/requestHelper";
+import { listForEvent } from "@/services/commentService";
+import { buildRequestData } from "@/requests/utils";
+import { BadInputError } from "@/types/errors/InputError";
+
+export const listComments = asyncHandler(async (req: Request, res: Response) => {
+    if (!req.params.eventId) {
+        throw new BadInputError("eventId", "Event ID is required");
+    }
+
+    const result = await listForEvent(req.params.eventId, buildRequestData(req));
+    setSuccessResponse(res, {
+        total: result.total,
+        entities: result.entities.map(comment => comment.toJSON())
+    });
+});

--- a/app/src/routes/comment.ts
+++ b/app/src/routes/comment.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { createComment } from "@/requests/comment/createComment";
+import { listComments } from "@/requests/comment/listComments";
+import { requestSchemaValidate } from "@/middlewares/requestSchemaValidate";
+import { authMiddleware } from "@/middlewares/authMiddleware";
+import { paginateMiddleware } from "@/middlewares/paginateMiddleware";
+import { CreateEventCommentSchema } from "@/schemas/http/Comment";
+
+export const router = Router();
+
+router.get("/:eventId", paginateMiddleware, listComments);
+router.post("/", [authMiddleware, requestSchemaValidate(CreateEventCommentSchema)], createComment);

--- a/app/src/routes/comment.ts
+++ b/app/src/routes/comment.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { createComment } from "@/requests/comment/createComment";
+import { deleteComment } from "@/requests/comment/deleteComment";
 import { listComments } from "@/requests/comment/listComments";
 import { requestSchemaValidate } from "@/middlewares/requestSchemaValidate";
 import { authMiddleware } from "@/middlewares/authMiddleware";
@@ -10,3 +11,4 @@ export const router = Router();
 
 router.get("/:eventId", paginateMiddleware, listComments);
 router.post("/", [authMiddleware, requestSchemaValidate(CreateEventCommentSchema)], createComment);
+router.delete("/:commentId", [authMiddleware], deleteComment);

--- a/app/src/routes/main.ts
+++ b/app/src/routes/main.ts
@@ -6,6 +6,7 @@ import { router as userRouter } from '@/routes/user'
 import { router as interestRouter } from '@/routes/interest';
 import { router as categoryRouter } from '@/routes/categories';
 import { router as rsvpRouter } from '@/routes/rsvp';
+import { router as commentRouter } from '@/routes/comment';
 
 export const router = Router()
 
@@ -16,3 +17,4 @@ router.use('/user', userRouter)
 router.use('/interests', interestRouter)
 router.use('/categories', categoryRouter)
 router.use('/rsvp', rsvpRouter)
+router.use('/comments', commentRouter)

--- a/app/src/schemas/http/Comment.ts
+++ b/app/src/schemas/http/Comment.ts
@@ -1,0 +1,16 @@
+import * as z from "zod";
+import { Types } from "mongoose";
+import messages from "@/constants/errorMessages";
+
+export const CreateEventCommentSchema = z.object({
+    eventId: z.string().refine(
+        id => Types.ObjectId.isValid(id),
+        {
+            message: messages.http.INVALID_ID("Event ID")
+        }
+    ),
+    content: z.string()
+        .trim()
+        .min(1, { message: messages.http.MIN_LENGTH("Comment", 1) })
+        .max(500, { message: messages.http.MAX_LENGTH("Comment", 500) })
+}).strict();

--- a/app/src/seeders/events.seeder.ts
+++ b/app/src/seeders/events.seeder.ts
@@ -1,11 +1,24 @@
 import { Event } from "@/models/event/Event";
 import { EventType } from "@/models/EventType";
 import { Category } from "@/models/category/Category";
+import { Comment } from "@/models/comment/Comment";
 import { RSVP } from "@/models/rsvp/RSVP";
 import { User } from "@/models/user/User";
 import { Types } from "mongoose";
 
 const EVENT_HOURS = [18, 19, 20, 9, 16, 17, 12, 15, 14, 21];
+const COMMENT_CONTENTS = [
+    "This looks like a strong lineup. I am planning to join.",
+    "Is there anything attendees should bring?",
+    "Great venue choice. Looking forward to meeting everyone.",
+    "Will there be time for networking after the main session?",
+    "I have been waiting for an event like this in the city.",
+    "The agenda sounds useful. Count me in.",
+    "Can guests still register if they decide last minute?",
+    "Excited to hear more details from the organizers.",
+    "This should be a good fit for first-time attendees.",
+    "Thanks for putting this together."
+];
 
 type RandomFn = () => number;
 
@@ -147,6 +160,7 @@ export function buildSeedEventDates(
 }
 
 export async function seed() {
+    await Comment.deleteMany({});
     await RSVP.deleteMany({});
     await Event.deleteMany({});
 
@@ -366,7 +380,29 @@ export async function seed() {
         type: randomEventTypeId(),
     }));
 
-    await Event.insertMany(eventsToInsert);
+    const createdEvents = await Event.insertMany(eventsToInsert);
+    const activeEvents = createdEvents.filter(event => event.active);
+    const commentsToInsert = activeEvents.flatMap((event, eventIndex) => {
+        const firstAuthor = users[eventIndex % users.length]._id;
+        const secondAuthor = users[(eventIndex + 1) % users.length]._id;
+        const firstContent = COMMENT_CONTENTS[(eventIndex * 2) % COMMENT_CONTENTS.length];
+        const secondContent = COMMENT_CONTENTS[(eventIndex * 2 + 1) % COMMENT_CONTENTS.length];
+
+        return [
+            {
+                event: event._id,
+                author: firstAuthor,
+                content: firstContent
+            },
+            {
+                event: event._id,
+                author: secondAuthor,
+                content: secondContent
+            }
+        ];
+    });
+
+    await Comment.insertMany(commentsToInsert);
 
     if (!process.env.JEST_WORKER_ID) {
         console.log("Events seeding done.");

--- a/app/src/seeders/runner.ts
+++ b/app/src/seeders/runner.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import { connectToMongo } from "@/config/mongoConfig";
 import { Category } from "@/models/category/Category";
+import { Comment } from "@/models/comment/Comment";
 import { Event } from "@/models/event/Event";
 import { EventType } from "@/models/EventType";
 import { Interest } from "@/models/Interest";
@@ -11,6 +12,7 @@ const seeders = ["categories", "interests", "users", "eventtypes", "events"] as 
 
 const resetters: Record<(typeof seeders)[number], () => Promise<void>> = {
   categories: async () => {
+    await Comment.deleteMany({});
     await RSVP.deleteMany({});
     await Event.deleteMany({});
     await Category.deleteMany({});
@@ -19,22 +21,26 @@ const resetters: Record<(typeof seeders)[number], () => Promise<void>> = {
     await Interest.deleteMany({});
   },
   users: async () => {
+    await Comment.deleteMany({});
     await RSVP.deleteMany({});
     await Event.deleteMany({});
     await User.deleteMany({});
   },
   eventtypes: async () => {
+    await Comment.deleteMany({});
     await RSVP.deleteMany({});
     await Event.deleteMany({});
     await EventType.deleteMany({});
   },
   events: async () => {
+    await Comment.deleteMany({});
     await RSVP.deleteMany({});
     await Event.deleteMany({});
   }
 };
 
 async function resetSeedData() {
+  await Comment.deleteMany({});
   await RSVP.deleteMany({});
   await Event.deleteMany({});
   await User.deleteMany({});

--- a/app/src/services/commentService.ts
+++ b/app/src/services/commentService.ts
@@ -1,7 +1,7 @@
 import { Comment, type HydratedComment } from "@/models/comment/Comment";
 import { Event } from "@/models/event/Event";
 import { logger } from "@/config/loggerConfig";
-import { NotFoundError } from "@/types/errors/InputError";
+import { ForbiddenError, NotFoundError } from "@/types/errors/InputError";
 import type { RequestData } from "@/types/common";
 import type { CreateCommentInput } from "@/types/services/commentService";
 
@@ -54,4 +54,22 @@ export async function listForEvent(eventId: string, data: RequestData): Promise<
         total,
         entities
     };
+}
+
+export async function deleteComment(commentId: string, userId: string) {
+    try {
+        const comment = await Comment.findById(commentId);
+        if (!comment) {
+            throw new NotFoundError("comment");
+        }
+        if (comment.author.toString() !== userId) {
+            throw new ForbiddenError("Only the comment author can delete this comment");
+        }
+
+        await comment.deleteOne();
+        return comment;
+    } catch (error) {
+        logger.error(`Error while deleting comment ${commentId}:`, error);
+        throw error;
+    }
 }

--- a/app/src/services/commentService.ts
+++ b/app/src/services/commentService.ts
@@ -1,0 +1,57 @@
+import { Comment, type HydratedComment } from "@/models/comment/Comment";
+import { Event } from "@/models/event/Event";
+import { logger } from "@/config/loggerConfig";
+import { NotFoundError } from "@/types/errors/InputError";
+import type { RequestData } from "@/types/common";
+import type { CreateCommentInput } from "@/types/services/commentService";
+
+export interface CommentListResult {
+    total: number;
+    entities: HydratedComment[];
+}
+
+async function assertActiveEvent(eventId: string) {
+    const event = await Event.findOne({ _id: eventId, active: true });
+    if (!event) {
+        throw new NotFoundError("event");
+    }
+
+    return event;
+}
+
+export async function create(data: CreateCommentInput, userId: string) {
+    const eventId = data.eventId;
+    const event = await assertActiveEvent(eventId);
+
+    try {
+        const comment = await Comment.create({
+            event: event._id,
+            author: userId,
+            content: data.content
+        });
+        await comment.populate("author", "_id username avatarUrl");
+        return comment;
+    } catch (error) {
+        logger.error(`Error while creating comment for event ${eventId}:`, error);
+        throw error;
+    }
+}
+
+export async function listForEvent(eventId: string, data: RequestData): Promise<CommentListResult> {
+    await assertActiveEvent(eventId);
+
+    const query = Comment.find({ event: eventId })
+        .populate("author", "_id username avatarUrl")
+        .sort({ createdAt: -1 })
+        .paginate(data.pagination.offset, data.pagination.limit);
+
+    const [total, entities] = await Promise.all([
+        Comment.countDocuments({ event: eventId }),
+        query
+    ]);
+
+    return {
+        total,
+        entities
+    };
+}

--- a/app/src/services/userService.ts
+++ b/app/src/services/userService.ts
@@ -2,6 +2,7 @@ import { User } from "@/models/user/User";
 import { Event } from "@/models/event/Event";
 import { NotFoundError } from "@/types/errors/InputError";
 import { RSVP } from "@/models/rsvp/RSVP";
+import { Comment } from "@/models/comment/Comment";
 
 export async function deleteUser(userId: string) {
     const user = await User.findOne({ _id: userId, active: true });
@@ -14,6 +15,7 @@ export async function deleteUser(userId: string) {
     await user.save();
 
     await RSVP.cancelForUser(user._id);
+    await Comment.deleteForAuthor(user._id);
     await Event.softDeleteByAuthor(user._id);
 
     return user;

--- a/app/src/types/services/commentService.ts
+++ b/app/src/types/services/commentService.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { CreateEventCommentSchema } from "@/schemas/http/Comment";
+
+export type CreateCommentInput = z.infer<typeof CreateEventCommentSchema>;

--- a/app/tests/generators/comment.ts
+++ b/app/tests/generators/comment.ts
@@ -7,6 +7,8 @@ type FakeComment = Omit<IComment, "_id" | "event" | "author"> & {
     author: string;
 };
 
+let commentSequence = 0;
+
 export async function createFakeComment(overrides?: Partial<FakeComment>, save?: false): Promise<FakeComment>;
 export async function createFakeComment(overrides: Partial<FakeComment>, save: true): Promise<HydratedComment>;
 export async function createFakeComment(overrides: Partial<FakeComment> = {}, save = false): Promise<FakeComment | HydratedComment> {
@@ -23,7 +25,7 @@ export async function createFakeComment(overrides: Partial<FakeComment> = {}, sa
     const commentData = {
         event: overrides.event ?? new Types.ObjectId().toString(),
         author: overrides.author ?? new Types.ObjectId().toString(),
-        content: "Sample comment " + Math.random().toString(36).substring(7),
+        content: `Sample comment ${commentSequence += 1}`,
         ...overrides
     };
 

--- a/app/tests/generators/comment.ts
+++ b/app/tests/generators/comment.ts
@@ -1,0 +1,35 @@
+import { Comment, type HydratedComment, type IComment } from "@/models/comment/Comment";
+import { Types } from "mongoose";
+import { getOneEvent, getOneUser } from "@tests/getters";
+
+type FakeComment = Omit<IComment, "_id" | "event" | "author"> & {
+    event: string;
+    author: string;
+};
+
+export async function createFakeComment(overrides?: Partial<FakeComment>, save?: false): Promise<FakeComment>;
+export async function createFakeComment(overrides: Partial<FakeComment>, save: true): Promise<HydratedComment>;
+export async function createFakeComment(overrides: Partial<FakeComment> = {}, save = false): Promise<FakeComment | HydratedComment> {
+    if (!overrides.event && save) {
+        const event = await getOneEvent({ active: true });
+        overrides.event = event._id.toString();
+    }
+
+    if (!overrides.author && save) {
+        const author = await getOneUser({ active: true });
+        overrides.author = author._id.toString();
+    }
+
+    const commentData = {
+        event: overrides.event ?? new Types.ObjectId().toString(),
+        author: overrides.author ?? new Types.ObjectId().toString(),
+        content: "Sample comment " + Math.random().toString(36).substring(7),
+        ...overrides
+    };
+
+    if (save) {
+        return Comment.create(commentData);
+    }
+
+    return commentData as FakeComment;
+}

--- a/app/tests/generators/comment.ts
+++ b/app/tests/generators/comment.ts
@@ -22,10 +22,12 @@ export async function createFakeComment(overrides: Partial<FakeComment> = {}, sa
         overrides.author = author._id.toString();
     }
 
+    commentSequence += 1;
+
     const commentData = {
         event: overrides.event ?? new Types.ObjectId().toString(),
         author: overrides.author ?? new Types.ObjectId().toString(),
-        content: `Sample comment ${commentSequence += 1}`,
+        content: `Sample comment ${commentSequence}`,
         ...overrides
     };
 

--- a/app/tests/generators/event.ts
+++ b/app/tests/generators/event.ts
@@ -2,7 +2,7 @@ import { IEvent, Event, type HydratedEvent } from "@/models/event/Event";
 import { Types } from "mongoose";
 import { getOneCategory, getOneEventType, getOneUser } from "@tests/getters";
 
-type FakeEvent = Omit<IEvent, "date" | "categories" | "type" | "author"> & {
+export type FakeEvent = Omit<IEvent, "date" | "categories" | "type" | "author"> & {
     date: number;
     categories: string[];
     type: string;

--- a/app/tests/generators/event.ts
+++ b/app/tests/generators/event.ts
@@ -1,4 +1,4 @@
-import { IEvent, Event } from "@/models/event/Event";
+import { IEvent, Event, type HydratedEvent } from "@/models/event/Event";
 import { Types } from "mongoose";
 import { getOneCategory, getOneEventType, getOneUser } from "@tests/getters";
 
@@ -9,8 +9,9 @@ type FakeEvent = Omit<IEvent, "date" | "categories" | "type" | "author"> & {
     author: string;
 };
 
-
-export async function createFakeEvent(overrides: Partial<FakeEvent> = {}, save = false) {
+export async function createFakeEvent(overrides?: Partial<FakeEvent>, save?: false): Promise<FakeEvent>;
+export async function createFakeEvent(overrides: Partial<FakeEvent>, save: true): Promise<HydratedEvent>;
+export async function createFakeEvent(overrides: Partial<FakeEvent> = {}, save = false): Promise<FakeEvent | HydratedEvent> {
     if (!overrides.categories) {
         const category = await getOneCategory();
         overrides.categories = [category._id.toString()];
@@ -42,6 +43,6 @@ export async function createFakeEvent(overrides: Partial<FakeEvent> = {}, save =
         const event = await Event.create(eventData);
         return event;
     } else {
-        return eventData;
+        return eventData as FakeEvent;
     }
 }

--- a/app/tests/models/comment.test.ts
+++ b/app/tests/models/comment.test.ts
@@ -1,0 +1,53 @@
+import mongoose from "mongoose";
+import { Comment } from "@/models/comment/Comment";
+import { createUser } from "@tests/generators/user";
+import { createFakeEvent } from "@tests/generators/event";
+import { createFakeComment } from "@tests/generators/comment";
+import { parseMongooseValidationError } from "@/helpers/requestHelper";
+import messages from "@/constants/errorMessages";
+
+describe("Comment model", () => {
+    it("Should save a comment for an active event", async () => {
+        const user = await createUser({}, true);
+        const event = await createFakeEvent({ author: user._id.toString() }, true);
+        const comment = await Comment.create({
+            event: event._id,
+            author: user._id,
+            content: "Nice event"
+        });
+
+        expect(comment.content).toBe("Nice event");
+        expect(comment.event.toString()).toBe(event._id.toString());
+        expect(comment.author.toString()).toBe(user._id.toString());
+    });
+
+    it("Should reject comments for inactive events", async () => {
+        const user = await createUser({}, true);
+        const event = await createFakeEvent({ author: user._id.toString() }, true);
+        event.active = false;
+        await event.save();
+
+        try {
+            await Comment.create({
+                event: event._id,
+                author: user._id,
+                content: "Will not save"
+            });
+        } catch (error) {
+            expect(error).toBeInstanceOf(mongoose.Error.ValidationError);
+            const parsedError = parseMongooseValidationError(error as mongoose.Error.ValidationError);
+            expect(parsedError).toHaveProperty("event");
+            expect(parsedError.event).toEqual([messages.validation.NOT_EXISTS("event")]);
+        }
+    });
+
+    it("Should remove comments for an event through the static helper", async () => {
+        const comment = await createFakeComment({}, true);
+        const eventId = comment.event.toString();
+
+        await Comment.deleteForEvent(eventId);
+
+        const storedComments = await Comment.find({ event: eventId });
+        expect(storedComments).toHaveLength(0);
+    });
+});

--- a/app/tests/models/rsvp/validators.test.ts
+++ b/app/tests/models/rsvp/validators.test.ts
@@ -6,10 +6,10 @@ import { Types } from "mongoose";
 import { createFakeEvent } from "../../generators/event";
 import { RSVP } from "@/models/rsvp/RSVP";
 import { STATUS_CONFIRMED } from "@/models/rsvp/utils";
-import { Event } from "@/models/event/Event";
+import { Event, type HydratedEvent } from "@/models/event/Event";
 import { createUser } from "@tests/generators/user";
 
-function getSavedEventId(event: Awaited<ReturnType<typeof createFakeEvent>>) {
+function getSavedEventId(event: HydratedEvent) {
     if (!event._id) {
         throw new Error("Failed to create fake event");
     }

--- a/app/tests/openapi/generate.test.ts
+++ b/app/tests/openapi/generate.test.ts
@@ -15,6 +15,7 @@ describe("generateOpenApiSpec", () => {
         expect(spec.paths).toHaveProperty("/status");
         expect(spec.paths).toHaveProperty("/api/auth/login");
         expect(spec.paths).toHaveProperty("/api/comments");
+        expect(spec.paths).toHaveProperty("/api/comments/{commentId}");
         expect(spec.paths).toHaveProperty("/api/comments/{eventId}");
         expect(spec.paths).toHaveProperty("/api/event/me");
         expect(spec.paths).toHaveProperty("/api/event/{eventId}");
@@ -45,6 +46,7 @@ describe("generateOpenApiSpec", () => {
         const eventDetailOperation = asRecord(asRecord(spec.paths["/api/event/{eventId}"]).get);
         const eventCommentsOperation = asRecord(asRecord(spec.paths["/api/comments/{eventId}"]).get);
         const createEventCommentsOperation = asRecord(asRecord(spec.paths["/api/comments"]).post);
+        const deleteCommentOperation = asRecord(asRecord(spec.paths["/api/comments/{commentId}"]).delete);
         const eventRsvpsOperation = asRecord(asRecord(spec.paths["/api/event/{eventId}/rsvps"]).get);
         const currentUserRsvpOperation = asRecord(asRecord(spec.paths["/api/event/{eventId}/rsvps/me"]).get);
         const eventListParameters = eventListOperation.parameters as { name: string }[];
@@ -82,6 +84,8 @@ describe("generateOpenApiSpec", () => {
             "limit"
         ]));
         expect(createEventCommentsOperation.responses).toHaveProperty("201");
+        expect(deleteCommentOperation.responses).toHaveProperty("200");
+        expect(deleteCommentOperation.security).toEqual([{ bearerAuth: [] }]);
         expect(eventTypeParameters.map(parameter => parameter.name)).toEqual(expect.arrayContaining([
             "title_eq",
             "title_contains"

--- a/app/tests/openapi/generate.test.ts
+++ b/app/tests/openapi/generate.test.ts
@@ -14,6 +14,8 @@ describe("generateOpenApiSpec", () => {
         expect(spec.openapi).toBe("3.1.0");
         expect(spec.paths).toHaveProperty("/status");
         expect(spec.paths).toHaveProperty("/api/auth/login");
+        expect(spec.paths).toHaveProperty("/api/comments");
+        expect(spec.paths).toHaveProperty("/api/comments/{eventId}");
         expect(spec.paths).toHaveProperty("/api/event/me");
         expect(spec.paths).toHaveProperty("/api/event/{eventId}");
         expect(spec.paths).toHaveProperty("/api/event/{eventId}/rsvps");
@@ -41,9 +43,12 @@ describe("generateOpenApiSpec", () => {
         const spec = generateOpenApiSpec();
         const eventListOperation = asRecord(asRecord(spec.paths["/api/event"]).get);
         const eventDetailOperation = asRecord(asRecord(spec.paths["/api/event/{eventId}"]).get);
+        const eventCommentsOperation = asRecord(asRecord(spec.paths["/api/comments/{eventId}"]).get);
+        const createEventCommentsOperation = asRecord(asRecord(spec.paths["/api/comments"]).post);
         const eventRsvpsOperation = asRecord(asRecord(spec.paths["/api/event/{eventId}/rsvps"]).get);
         const currentUserRsvpOperation = asRecord(asRecord(spec.paths["/api/event/{eventId}/rsvps/me"]).get);
         const eventListParameters = eventListOperation.parameters as { name: string }[];
+        const eventCommentsParameters = eventCommentsOperation.parameters as { name: string }[];
         const eventTypeOperation = asRecord(asRecord(spec.paths["/api/event/types"]).get);
         const eventTypeParameters = eventTypeOperation.parameters as { name: string }[];
         const interestsOperation = asRecord(asRecord(spec.paths["/api/interests"]).get);
@@ -71,6 +76,12 @@ describe("generateOpenApiSpec", () => {
             "sortByDesc",
             "search"
         ]));
+        expect(eventCommentsParameters.map(parameter => parameter.name)).toEqual(expect.arrayContaining([
+            "eventId",
+            "page",
+            "limit"
+        ]));
+        expect(createEventCommentsOperation.responses).toHaveProperty("201");
         expect(eventTypeParameters.map(parameter => parameter.name)).toEqual(expect.arrayContaining([
             "title_eq",
             "title_contains"

--- a/app/tests/requests/event/create.test.ts
+++ b/app/tests/requests/event/create.test.ts
@@ -9,19 +9,22 @@ import { Category } from "@/models/category/Category"
 import { EventType } from "@/models/EventType"
 import { CreateEventSchema } from "@/schemas/http/Event";
 import { CreateEventInput } from "@/types/services/eventService"
+import { Event } from "@/models/event/Event";
 jest.mock("@/services/eventService")
 jest.mock("@/helpers/requestHelper")
 jest.mock("@/schemas/http/Event");
 
 let res = getMockedResponse();
-let mockEvent: MockedJsonDocument<FakeEvent>;
+type CreatedEvent = Awaited<ReturnType<typeof createEvent>>;
+let mockEvent: MockedJsonDocument<CreatedEvent>;
 let newEvent: FakeEvent;
 const next = jest.fn() as NextFunction;
 let categoriesIds: string[];
 let eventTypeId: string;
 
 beforeAll(async () => {
-    const event = await createFakeEvent();
+    const savedEvent = await createFakeEvent({}, true);
+    const event = await Event.findById(savedEvent._id).orFail();
     mockEvent = withToJSON(event);
     const categories = await Category.find().limit(2);
     const eventType = await EventType.findOne();
@@ -35,7 +38,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
     jest.resetAllMocks();
-    jest.mocked(createEvent).mockResolvedValue(mockEvent as never);
+    jest.mocked(createEvent).mockResolvedValue(mockEvent);
     jest.mocked(CreateEventSchema.parse).mockReturnValue(newEvent as CreateEventInput);
     res = getMockedResponse();
 

--- a/app/tests/requests/event/create.test.ts
+++ b/app/tests/requests/event/create.test.ts
@@ -3,7 +3,7 @@ import { getMockedRequest, getMockedResponse, MockedJsonDocument, withToJSON } f
 import mongoose from "mongoose"
 import { NextFunction } from "express"
 import { create as createEvent } from "@/services/eventService"
-import { createFakeEvent } from "../../generators/event"
+import { createFakeEvent, type FakeEvent } from "../../generators/event"
 import { setSuccessResponse } from "@/helpers/requestHelper"
 import { Category } from "@/models/category/Category"
 import { EventType } from "@/models/EventType"
@@ -14,8 +14,8 @@ jest.mock("@/helpers/requestHelper")
 jest.mock("@/schemas/http/Event");
 
 let res = getMockedResponse();
-let mockEvent: MockedJsonDocument<Awaited<ReturnType<typeof createFakeEvent>>>;
-let newEvent: Awaited<ReturnType<typeof createFakeEvent>>;
+let mockEvent: MockedJsonDocument<FakeEvent>;
+let newEvent: FakeEvent;
 const next = jest.fn() as NextFunction;
 let categoriesIds: string[];
 let eventTypeId: string;

--- a/app/tests/requests/event/delete.test.ts
+++ b/app/tests/requests/event/delete.test.ts
@@ -14,8 +14,10 @@ jest.mock("@/middlewares/authMiddleware", () => ({
 import app from "@/app";
 import { createFakeEvent } from "@tests/generators/event";
 import { createFakeRSVP } from "@tests/generators/rsvp";
+import { createFakeComment } from "@tests/generators/comment";
 import { Event } from "@/models/event/Event";
 import { RSVP } from "@/models/rsvp/RSVP";
+import { Comment } from "@/models/comment/Comment";
 import { STATUS_CANCELED, STATUS_CONFIRMED } from "@/models/rsvp/utils";
 
 describe("DELETE /api/event/:eventId", () => {
@@ -33,6 +35,11 @@ describe("DELETE /api/event/:eventId", () => {
             status: STATUS_CONFIRMED,
             eventDate
         }, true);
+        await createFakeComment({
+            event: event._id.toString(),
+            author: attendee._id.toString(),
+            content: "Great event"
+        }, true);
 
         const res = await request(app).delete(`/api/event/${event._id.toString()}`).send();
         expect(res.statusCode).toBe(200);
@@ -40,12 +47,14 @@ describe("DELETE /api/event/:eventId", () => {
 
         const deletedEvent = await Event.findById(event._id);
         const rsvps = await RSVP.find({ event: event._id });
+        const comments = await Comment.find({ event: event._id });
         const fetchDeletedRes = await request(app).get(`/api/event/${event._id.toString()}`).send();
         const listRes = await request(app).get("/api/event").send();
         const eventId = event._id.toString();
 
         expect(deletedEvent?.active).toBe(false);
         expect(rsvps.every(rsvp => rsvp.status === STATUS_CANCELED)).toBe(true);
+        expect(comments).toHaveLength(0);
         expect(fetchDeletedRes.statusCode).toBe(404);
         expect(listRes.body.data.some((listedEvent: { _id: string }) => listedEvent._id === eventId)).toBe(false);
     });

--- a/app/tests/requests/event/geosearch.test.ts
+++ b/app/tests/requests/event/geosearch.test.ts
@@ -1,19 +1,20 @@
 import { NextFunction } from "express"
 import { ParsedQs } from "qs";
 import { geoSearch as serviceGeoSearch } from "@/services/eventService";
-import { createFakeEvent, type FakeEvent } from "../../generators/event"
+import { createFakeEvent } from "../../generators/event"
 import { setSuccessResponse } from "@/helpers/requestHelper";
 import { getMockedRequest, getMockedResponse, MockedJsonDocument, withToJSON } from "../../utils";
 import { geosearch } from "@/requests/event/geosearch";
 import { ZodError } from "zod";
 import { CoordinatesSchema } from "@/schemas/http/Event";
 import { buildRequestData } from "@/requests/utils";
+import { type HydratedEvent } from "@/models/event/Event";
 jest.mock("@/services/eventService")
 jest.mock("@/helpers/requestHelper")
 jest.mock("@/schemas/http/Event")
 
 let res = getMockedResponse();
-let mockEvent: MockedJsonDocument<FakeEvent>;
+let mockEvent: MockedJsonDocument<HydratedEvent>;
 let result: typeof mockEvent[] = [];
 const next = jest.fn() as NextFunction;
 const coordinates = {
@@ -23,14 +24,14 @@ const coordinates = {
 };
 const coordinateQuery = coordinates as unknown as ParsedQs;
 beforeAll(async () => {
-    const event = await createFakeEvent();
+    const event = await createFakeEvent({}, true);
     mockEvent = withToJSON(event);
     result = [mockEvent, mockEvent];
 });
 
 beforeEach(() => {
     jest.resetAllMocks();
-    jest.mocked(serviceGeoSearch).mockResolvedValue(result as never);
+    jest.mocked(serviceGeoSearch).mockResolvedValue(result);
     jest.mocked(CoordinatesSchema.parse).mockReturnValue(coordinates);
     res = getMockedResponse();
 

--- a/app/tests/requests/event/geosearch.test.ts
+++ b/app/tests/requests/event/geosearch.test.ts
@@ -1,7 +1,7 @@
 import { NextFunction } from "express"
 import { ParsedQs } from "qs";
 import { geoSearch as serviceGeoSearch } from "@/services/eventService";
-import { createFakeEvent } from "../../generators/event"
+import { createFakeEvent, type FakeEvent } from "../../generators/event"
 import { setSuccessResponse } from "@/helpers/requestHelper";
 import { getMockedRequest, getMockedResponse, MockedJsonDocument, withToJSON } from "../../utils";
 import { geosearch } from "@/requests/event/geosearch";
@@ -13,7 +13,7 @@ jest.mock("@/helpers/requestHelper")
 jest.mock("@/schemas/http/Event")
 
 let res = getMockedResponse();
-let mockEvent: MockedJsonDocument<Awaited<ReturnType<typeof createFakeEvent>>>;
+let mockEvent: MockedJsonDocument<FakeEvent>;
 let result: typeof mockEvent[] = [];
 const next = jest.fn() as NextFunction;
 const coordinates = {

--- a/app/tests/requests/event/update.test.ts
+++ b/app/tests/requests/event/update.test.ts
@@ -2,7 +2,7 @@ import { NextFunction } from "express"
 import { update as updateEvent } from "@/services/eventService";
 import { getMockedRequest, getMockedResponse, MockedJsonDocument, withToJSON } from "../../utils";
 import mongoose from "mongoose";
-import { createFakeEvent } from "../../generators/event"
+import { createFakeEvent, type FakeEvent } from "../../generators/event"
 import { setSuccessResponse } from "@/helpers/requestHelper";
 import { update } from "@/requests/event/update";
 
@@ -12,7 +12,7 @@ jest.mock("@/helpers/requestHelper")
 
 let res = getMockedResponse();
 const next = jest.fn() as NextFunction;
-let mockEvent: MockedJsonDocument<Awaited<ReturnType<typeof createFakeEvent>>>;
+let mockEvent: MockedJsonDocument<FakeEvent>;
 beforeAll(async () => {
     const event = await createFakeEvent();
     mockEvent = withToJSON(event);

--- a/app/tests/requests/event/update.test.ts
+++ b/app/tests/requests/event/update.test.ts
@@ -2,9 +2,10 @@ import { NextFunction } from "express"
 import { update as updateEvent } from "@/services/eventService";
 import { getMockedRequest, getMockedResponse, MockedJsonDocument, withToJSON } from "../../utils";
 import mongoose from "mongoose";
-import { createFakeEvent, type FakeEvent } from "../../generators/event"
+import { createFakeEvent } from "../../generators/event"
 import { setSuccessResponse } from "@/helpers/requestHelper";
 import { update } from "@/requests/event/update";
+import { Event } from "@/models/event/Event";
 
 jest.mock("@/services/eventService")
 jest.mock("@/helpers/requestHelper")
@@ -12,14 +13,16 @@ jest.mock("@/helpers/requestHelper")
 
 let res = getMockedResponse();
 const next = jest.fn() as NextFunction;
-let mockEvent: MockedJsonDocument<FakeEvent>;
+type UpdatedEvent = Awaited<ReturnType<typeof updateEvent>>;
+let mockEvent: MockedJsonDocument<UpdatedEvent>;
 beforeAll(async () => {
-    const event = await createFakeEvent();
+    const savedEvent = await createFakeEvent({}, true);
+    const event = await Event.findById(savedEvent._id).orFail();
     mockEvent = withToJSON(event);
 })
 beforeEach(() => {
     jest.resetAllMocks();
-    jest.mocked(updateEvent).mockResolvedValue(mockEvent as never)
+    jest.mocked(updateEvent).mockResolvedValue(mockEvent)
     res = getMockedResponse();
 
 })

--- a/app/tests/requests/events.test.ts
+++ b/app/tests/requests/events.test.ts
@@ -16,6 +16,7 @@ jest.mock("@/middlewares/authMiddleware", () => ({
     ),
 }));
 import app from "@/app";
+import { Comment } from "@/models/comment/Comment";
 import { Event } from "@/models/event/Event";
 import { Category } from "@/models/category/Category";
 import { EventType } from "@/models/EventType";
@@ -517,6 +518,8 @@ describe("GET /:eventId/rsvps", () => {
 describe("GET /comments/:eventId and POST /comments", () => {
     let eventId: string;
     let commenterId: string;
+    let firstCommentId: string;
+    let commenterUser: Awaited<ReturnType<typeof createUser>>;
 
     beforeAll(async () => {
         const author = await createUser({}, true);
@@ -539,6 +542,8 @@ describe("GET /comments/:eventId and POST /comments", () => {
 
         eventId = event._id.toString();
         commenterId = author._id.toString();
+        firstCommentId = firstComment._id.toString();
+        commenterUser = author;
     });
 
     it("Should list comments for an event", async () => {
@@ -564,5 +569,31 @@ describe("GET /comments/:eventId and POST /comments", () => {
         expect(res.body.data.event.toString()).toBe(eventId);
         expect(res.body.data).toHaveProperty("author");
         expect(res.body.data.author).toHaveProperty("_id", user._id.toString());
+    });
+
+    it("Should delete the current user's comment", async () => {
+        user = commenterUser;
+        const res = await request(app).delete(`/api/comments/${firstCommentId}`).send();
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data).toEqual({ message: "Comment has been deleted" });
+        await expect(Comment.findById(firstCommentId).orFail()).rejects.toThrow();
+    });
+
+    it("Should reject deleting another user's comment", async () => {
+        user = commenterUser;
+        const otherUser = await createUser({}, true);
+        const comment = await createFakeComment({
+            event: eventId,
+            author: otherUser._id.toString(),
+            content: "Not my comment"
+        }, true);
+
+        const res = await request(app).delete(`/api/comments/${comment._id.toString()}`).send();
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body.success).toBe(false);
+        expect(res.body.data.formErrors).toEqual(["Only the comment author can delete this comment"]);
+        await expect(Comment.findById(comment._id).orFail()).resolves.toBeTruthy();
     });
 });

--- a/app/tests/requests/events.test.ts
+++ b/app/tests/requests/events.test.ts
@@ -2,6 +2,7 @@ import request from "supertest";
 import { NextFunction, Request, Response } from "express";
 import { createUser } from "../generators/user";
 import { createFakeRSVP } from "../generators/rsvp";
+import { createFakeComment } from "@tests/generators/comment";
 import { Types } from "mongoose";
 
 let user: Awaited<ReturnType<typeof createUser>>;
@@ -510,5 +511,58 @@ describe("GET /:eventId/rsvps", () => {
 
     afterAll(async () => {
         await user.deleteOne();
+    });
+});
+
+describe("GET /comments/:eventId and POST /comments", () => {
+    let eventId: string;
+    let commenterId: string;
+
+    beforeAll(async () => {
+        const author = await createUser({}, true);
+        const event = await createFakeEvent({ author: author._id.toString() }, true);
+        const firstComment = await createFakeComment({
+            event: event._id.toString(),
+            author: author._id.toString(),
+            content: "First comment"
+        }, true);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        await createFakeComment({
+            event: event._id.toString(),
+            author: author._id.toString(),
+            content: "Second comment"
+        }, true);
+
+        if (!event?._id || !firstComment?._id) {
+            throw new Error("No comments found, check your seeders");
+        }
+
+        eventId = event._id.toString();
+        commenterId = author._id.toString();
+    });
+
+    it("Should list comments for an event", async () => {
+        const res = await request(app).get(`/api/comments/${eventId}`).send();
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toHaveProperty("data.total");
+        expect(res.body.data.total).toBeGreaterThanOrEqual(2);
+        expect(Array.isArray(res.body.data.entities)).toBe(true);
+        expect(res.body.data.entities[0]).toHaveProperty("author");
+        expect(res.body.data.entities[0].author).toHaveProperty("_id", commenterId);
+    });
+
+    it("Should create a comment for an event", async () => {
+        user = await createUser({}, true);
+        const requestBody = { eventId, content: "This event looks great" };
+        const res = await request(app).post("/api/comments").send(requestBody);
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body).toHaveProperty("data");
+        expect(res.body.data).toHaveProperty("content", requestBody.content);
+        expect(res.body.data).toHaveProperty("event");
+        expect(res.body.data.event.toString()).toBe(eventId);
+        expect(res.body.data).toHaveProperty("author");
+        expect(res.body.data.author).toHaveProperty("_id", user._id.toString());
     });
 });

--- a/app/tests/requests/user/deleteProfile.test.ts
+++ b/app/tests/requests/user/deleteProfile.test.ts
@@ -13,14 +13,21 @@ jest.mock("@/middlewares/authMiddleware", () => ({
 
 import app from "@/app";
 import { createFakeEvent } from "@tests/generators/event";
+import { createFakeComment } from "@tests/generators/comment";
 import successMessages from "@/constants/successMessages";
 import { User } from "@/models/user/User";
 import { Event } from "@/models/event/Event";
+import { Comment } from "@/models/comment/Comment";
 
 describe("DELETE /api/user", () => {
     it("Should soft delete the current user and their authored events", async () => {
         user = await createUser({}, true);
         const event = await createFakeEvent({ author: user._id.toString() }, true);
+        await createFakeComment({
+            event: event._id.toString(),
+            author: user._id.toString(),
+            content: "Owned comment"
+        }, true);
 
         const res = await request(app).delete("/api/user").send();
         expect(res.statusCode).toBe(200);
@@ -28,8 +35,10 @@ describe("DELETE /api/user", () => {
 
         const deletedUser = await User.findById(user._id);
         const deletedEvent = await Event.findById(event._id);
+        const comments = await Comment.find({ author: user._id });
 
         expect(deletedUser?.active).toBe(false);
         expect(deletedEvent?.active).toBe(false);
+        expect(comments).toHaveLength(0);
     });
 });

--- a/app/tests/seeders/events.seeder.test.ts
+++ b/app/tests/seeders/events.seeder.test.ts
@@ -1,4 +1,6 @@
-import { buildSeedEventDates } from "@/seeders/events.seeder";
+import { Comment } from "@/models/comment/Comment";
+import { Event } from "@/models/event/Event";
+import { buildSeedEventDates, seed as seedEvents } from "@/seeders/events.seeder";
 
 function startOfDay(value: Date): Date {
     return new Date(value.getFullYear(), value.getMonth(), value.getDate(), 0, 0, 0, 0);
@@ -65,5 +67,18 @@ describe("buildSeedEventDates()", () => {
         expect(thisWeekDate <= weekEnd).toBe(true);
         expect(isSameDay(thisWeekDate, referenceDate)).toBe(false);
         expect(randomMonthDates.every(date => isSameMonth(date, referenceDate))).toBe(true);
+    });
+});
+
+describe("events seeder", () => {
+    it("should seed comments for every active event", async () => {
+        await seedEvents();
+
+        const activeEvents = await Event.find({ active: true }, { _id: 1 }).lean();
+        const comments = await Comment.find({}).lean();
+        const activeEventIds = new Set(activeEvents.map(event => event._id.toString()));
+
+        expect(comments).toHaveLength(activeEvents.length * 2);
+        expect(comments.every(comment => activeEventIds.has(comment.event.toString()))).toBe(true);
     });
 });

--- a/app/tests/services/commentService.test.ts
+++ b/app/tests/services/commentService.test.ts
@@ -1,8 +1,9 @@
 import { createUser } from "@tests/generators/user";
 import { createFakeEvent } from "@tests/generators/event";
 import { createFakeComment } from "@tests/generators/comment";
-import { create, listForEvent } from "@/services/commentService";
-import { NotFoundError } from "@/types/errors/InputError";
+import { create, deleteComment, listForEvent } from "@/services/commentService";
+import { ForbiddenError, NotFoundError } from "@/types/errors/InputError";
+import { Comment } from "@/models/comment/Comment";
 
 describe("commentService.create()", () => {
     it("Should create a comment for an active event", async () => {
@@ -64,5 +65,31 @@ describe("commentService.listForEvent()", () => {
         await expect(listForEvent(event._id.toString(), {
             pagination: { offset: 0, limit: 10 }
         })).rejects.toBeInstanceOf(NotFoundError);
+    });
+});
+
+describe("commentService.deleteComment()", () => {
+    it("Should delete a comment authored by the user", async () => {
+        const author = await createUser({}, true);
+        const comment = await createFakeComment({ author: author._id.toString() }, true);
+
+        await deleteComment(comment._id.toString(), author._id.toString());
+
+        await expect(Comment.findById(comment._id).orFail()).rejects.toBeTruthy();
+    });
+
+    it("Should reject deleting another user's comment", async () => {
+        const owner = await createUser({}, true);
+        const otherUser = await createUser({}, true);
+        const comment = await createFakeComment({ author: owner._id.toString() }, true);
+
+        await expect(deleteComment(comment._id.toString(), otherUser._id.toString())).rejects.toBeInstanceOf(ForbiddenError);
+        await expect(Comment.findById(comment._id).orFail()).resolves.toBeTruthy();
+    });
+
+    it("Should reject deleting a missing comment", async () => {
+        const author = await createUser({}, true);
+
+        await expect(deleteComment(author._id.toString(), author._id.toString())).rejects.toBeInstanceOf(NotFoundError);
     });
 });

--- a/app/tests/services/commentService.test.ts
+++ b/app/tests/services/commentService.test.ts
@@ -1,0 +1,68 @@
+import { createUser } from "@tests/generators/user";
+import { createFakeEvent } from "@tests/generators/event";
+import { createFakeComment } from "@tests/generators/comment";
+import { create, listForEvent } from "@/services/commentService";
+import { NotFoundError } from "@/types/errors/InputError";
+
+describe("commentService.create()", () => {
+    it("Should create a comment for an active event", async () => {
+        const author = await createUser({}, true);
+        const event = await createFakeEvent({ author: author._id.toString() }, true);
+        const result = await create({ eventId: event._id.toString(), content: "Hello comments" }, author._id.toString());
+
+        expect(result.event.toString()).toBe(event._id.toString());
+        expect(result.author).toMatchObject({
+            _id: author._id,
+            username: author.username
+        });
+        expect(result.content).toBe("Hello comments");
+    });
+
+    it("Should reject comments for inactive events", async () => {
+        const author = await createUser({}, true);
+        const event = await createFakeEvent({ author: author._id.toString() }, true);
+        event.active = false;
+        await event.save();
+
+        await expect(create({ eventId: event._id.toString(), content: "Hello comments" }, author._id.toString())).rejects.toBeInstanceOf(NotFoundError);
+    });
+});
+
+describe("commentService.listForEvent()", () => {
+    it("Should return paginated comments in newest-first order", async () => {
+        const author = await createUser({}, true);
+        const event = await createFakeEvent({ author: author._id.toString() }, true);
+        const older = await createFakeComment({
+            event: event._id.toString(),
+            author: author._id.toString(),
+            content: "Older comment"
+        }, true);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        const newer = await createFakeComment({
+            event: event._id.toString(),
+            author: author._id.toString(),
+            content: "Newer comment"
+        }, true);
+
+        const result = await listForEvent(event._id.toString(), {
+            pagination: { offset: 0, limit: 10 }
+        });
+
+        expect(result.total).toBeGreaterThanOrEqual(2);
+        expect(result.entities.map(comment => comment._id.toString())).toEqual([
+            newer._id.toString(),
+            older._id.toString()
+        ]);
+    });
+
+    it("Should reject comments listing for inactive events", async () => {
+        const author = await createUser({}, true);
+        const event = await createFakeEvent({ author: author._id.toString() }, true);
+        event.active = false;
+        await event.save();
+
+        await expect(listForEvent(event._id.toString(), {
+            pagination: { offset: 0, limit: 10 }
+        })).rejects.toBeInstanceOf(NotFoundError);
+    });
+});


### PR DESCRIPTION
## Summary

- Add event comments as a dedicated comment model with active event/user validation.
- Add `POST /api/comments` with `eventId` in the body and `GET /api/comments/:eventId` for paginated event comments.
- Clean up comments when events or users are deleted, and document the endpoints in OpenAPI.

## Validation

- `npm test -- --config jest.config.ts --runInBand tests/services/commentService.test.ts tests/openapi/generate.test.ts tests/requests/events.test.ts`
- `npm run lint`
- `npm run build`
- `npm run openapi`

## Notes

- `.serena/project.yml` had an unrelated local modification and was intentionally left out of the commit.